### PR TITLE
Eedeleon/add blackbox extension

### DIFF
--- a/src/python/interpret/ext/__init__.py
+++ b/src/python/interpret/ext/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license

--- a/src/python/interpret/ext/blackbox/__init__.py
+++ b/src/python/interpret/ext/blackbox/__init__.py
@@ -1,0 +1,19 @@
+import logging
+import sys
+
+from interpret.ext.extension_utils import load_class_extensions
+
+module_logger = logging.getLogger(__name__)
+
+BLACKBOX_EXTENSION_KEY = "interpret_ext_blackbox"
+
+
+def _is_valid_blackbox_explainer(proposed_blackbox_explainer):
+    return True
+
+
+# How to get the current module
+# https://stackoverflow.com/questions/1676835
+current_module = sys.modules[__name__]
+
+load_class_extensions(current_module, BLACKBOX_EXTENSION_KEY, _is_valid_blackbox_explainer)

--- a/src/python/interpret/ext/blackbox/__init__.py
+++ b/src/python/interpret/ext/blackbox/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
 import logging
 import sys
 

--- a/src/python/interpret/ext/blackbox/__init__.py
+++ b/src/python/interpret/ext/blackbox/__init__.py
@@ -12,7 +12,10 @@ BLACKBOX_EXTENSION_KEY = "interpret_ext_blackbox"
 
 
 def _is_valid_blackbox_explainer(proposed_blackbox_explainer):
-    return True
+    for explanation_type in ["local", "global", "perf", "data"]:
+        if hasattr(proposed_blackbox_explainer, "explain_" + explanation_type):
+            return True
+    return False
 
 
 # How to get the current module

--- a/src/python/interpret/ext/blackbox/example_blackbox_explainer_ext.py
+++ b/src/python/interpret/ext/blackbox/example_blackbox_explainer_ext.py
@@ -1,0 +1,18 @@
+from interpret.api.base import ExplainerMixin
+
+
+class ExampleExplanation(object):
+    available_explanations = ["not_important"]
+    explainer_type = "demo"
+
+    def data(self, key=None):
+        return {"How": {"do": {"you": "do?"}}}
+
+    def visualize(self, key=None):
+        return {"here": "I am"}
+
+
+class ExampleExplainer(ExplainerMixin):
+    def explain_local(self, X, y=None, name=None):
+        print("Hello world")
+        return ExampleExplanation()

--- a/src/python/interpret/ext/blackbox/example_blackbox_explainer_ext.py
+++ b/src/python/interpret/ext/blackbox/example_blackbox_explainer_ext.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
 from interpret.api.base import ExplainerMixin
 
 

--- a/src/python/interpret/ext/extension_utils.py
+++ b/src/python/interpret/ext/extension_utils.py
@@ -1,0 +1,58 @@
+import logging
+import pkg_resources
+import re
+
+module_logger = logging.getLogger(__name__)
+
+blackbox_key = "interpret_ext_blackbox"
+
+
+def _validate_class_name(proposed_class_name):
+    """
+    Used to validate class names before registration.
+
+    :param proposed_class_name: The string to name the class
+    :type proposed_class_name: str
+    """
+    # regex for class name came from
+    # https://stackoverflow.com/questions/10120295
+    # TODO: Support other languages
+    match = re.match(r"[a-zA-Z_][a-zA-Z_0-9]+", proposed_class_name)
+    if match is None or match.group(0) != proposed_class_name:
+        raise ValueError("Invalid class name {}. Class names must start with a "
+                         " letter or underscore. And can continue with letters, "
+                         "underscores, and integers".format(proposed_class_name))
+
+
+def load_class_extensions(current_module, extension_key, extension_class_validator):
+    """
+    Load all registered extensions under the `extension_key` namespace in entry_points.
+
+    :param current_module: The module where extension classes should be added.
+    :type current_module: module
+    :param extension_key: The identifier for the entry_points to register within the current_module.
+    :type extension_key: str
+    :param extension_class_validator: A function that checks the class for correctness before it is registered.
+    :type extension_class_validator: function(class) -> bool
+    """
+    for entrypoint in pkg_resources.iter_entry_points(extension_key):
+        try:
+            extension_class_name = entrypoint.name
+            extension_class = entrypoint.load()
+            module_logger.debug("loading entrypoint key {} with name {} with object {}".format(
+                extension_key, extension_class_name, extension_class))
+
+            _validate_class_name(extension_class_name)
+
+            if not extension_class_validator(extension_class):
+                raise ValueError("class {} failed validation.".format(extension_class))
+
+            if getattr(current_module, extension_class_name, None) is not None:
+                raise ValueError("class name {} already exists for module {}.".format(
+                                 extension_class_name, current_module.__name__))
+
+            setattr(current_module, extension_class_name, extension_class)
+
+        except Exception as e:
+            module_logger.warning("Failure while loading {}. Failed to load entrypoint {} with exception {}.".format(
+                blackbox_key, entrypoint, e))

--- a/src/python/interpret/ext/extension_utils.py
+++ b/src/python/interpret/ext/extension_utils.py
@@ -23,8 +23,8 @@ def _validate_class_name(proposed_class_name):
     match = re.match(r"[a-zA-Z_][a-zA-Z_0-9]+", proposed_class_name)
     if match is None or match.group(0) != proposed_class_name:
         raise ValueError("Invalid class name {}. Class names must start with a "
-                         " letter or underscore. And can continue with letters, "
-                         "underscores, and integers".format(proposed_class_name))
+                         "letter or an underscore and can continue with letters, "
+                         "numbers, and underscores.".format(proposed_class_name))
 
 
 def load_class_extensions(current_module, extension_key, extension_class_validator):

--- a/src/python/interpret/ext/extension_utils.py
+++ b/src/python/interpret/ext/extension_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
 import logging
 import pkg_resources
 import re

--- a/src/python/interpret/test/test_ext_blackbox.py
+++ b/src/python/interpret/test/test_ext_blackbox.py
@@ -1,7 +1,9 @@
-import interpret.ext.blackbox
+from six import raise_from
 
 
 def test_import_demo_explainer():
-    print(dir(interpret.ext.blackbox))
-    from interpret.ext.blackbox import BlackboxExplainerExample
-    print("Loaded {}".format(BlackboxExplainerExample.__name__))
+    try:
+        from interpret.ext.blackbox import BlackboxExplainerExample  # noqa
+    except ImportError as import_error:
+        raise_from(Exception("Failure in interpret.ext.blackbox while trying "
+                             "to load example explainers through extension_utils", import_error))

--- a/src/python/interpret/test/test_ext_blackbox.py
+++ b/src/python/interpret/test/test_ext_blackbox.py
@@ -1,0 +1,7 @@
+import interpret.ext.blackbox
+
+
+def test_import_demo_explainer():
+    print(dir(interpret.ext.blackbox))
+    from interpret.ext.blackbox import BlackboxExplainerExample
+    print("Loaded {}".format(BlackboxExplainerExample.__name__))

--- a/src/python/interpret/test/test_ext_blackbox.py
+++ b/src/python/interpret/test/test_ext_blackbox.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
 from six import raise_from
 
 

--- a/src/python/interpret/test/test_extension_utils.py
+++ b/src/python/interpret/test/test_extension_utils.py
@@ -9,6 +9,7 @@ from interpret.ext.extension_utils import _validate_class_name
                                                ( "1332", False),
                                                ("&sgag", False),
                                                ("aaaaaa", True),
+                                               (",,,,", False),
                                                ("", False),
                                                ("_AmValid", True),
                                                ("_AM_NOT_NICE_BUT_VALID", True)])

--- a/src/python/interpret/test/test_extension_utils.py
+++ b/src/python/interpret/test/test_extension_utils.py
@@ -1,0 +1,18 @@
+import pytest
+from interpret.ext.extension_utils import _validate_class_name
+
+
+@pytest.mark.parametrize("name_and_is_valid", [("aagdsg.afds", False),
+                                               ( "1332", False),
+                                               ("&sgag", False),
+                                               ("aaaaaa", True),
+                                               ("", False),
+                                               ("_AmValid", True),
+                                               ("_AM_NOT_NICE_BUT_VALID", True)])
+def test_name_validation(name_and_is_valid):
+    name, is_valid = name_and_is_valid
+    if is_valid:
+        _validate_class_name(name)
+    else:
+        with pytest.raises(ValueError):
+            _validate_class_name(name)

--- a/src/python/interpret/test/test_extension_utils.py
+++ b/src/python/interpret/test/test_extension_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
 import pytest
 from interpret.ext.extension_utils import _validate_class_name
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -82,6 +82,11 @@ setup(
     },
     setup_requires=[] + dev_tools,
     tests_require=[] + dev_tools,
+    entry_points={
+        "interpret_ext_blackbox": [
+            "BlackboxExplainerExample = interpret.ext.blackbox.example_blackbox_explainer_ext:ExampleExplainer"
+            ]
+    },
     install_requires=[
         # Algorithms
         "SALib>=1.3.3",


### PR DESCRIPTION
Add an extension hook for blackbox explainers.

Downstream libraries can use the extension hook to add classes under the interpret.ext.blackbox namespace if validation is passed

Add an example class registration.


TODO
- decide on proper validation for blackbox explainers
- decide on a more useful example blackbox explainer
