### PR TITLE
Add multi-class post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 ![Build Status](https://img.shields.io/azure-devops/build/ms/interpret/151/master.svg?style=flat-square)
 ![Maintenance](https://img.shields.io/maintenance/yes/2019.svg?style=flat-square)
 
-*Equal contributions: Samuel Jenkins & Harsha Nori & Paul Koch & Rich Caruana*
-
 <br/>
 
 > ### In the beginning machines learned in darkness, and data scientists struggled in the void to explain them.
@@ -116,9 +114,9 @@ If you are interested contributing directly to the code base, please see [CONTRI
 
 ## Acknowledgements
 
-Many people have supported us along the way. Check out [ACKNOWLEDGEMENTS.md](./ACKNOWLEDGEMENTS.md)!
+InterpretML was originally created by (equal contributions): Samuel Jenkins & Harsha Nori & Paul Koch & Rich Caruana
 
-<br/>
+Many people have supported us along the way. Check out [ACKNOWLEDGEMENTS.md](./ACKNOWLEDGEMENTS.md)!
 
 We also build on top of many great packages. Please check them out!
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,9 +171,9 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
   - script: |
-      sudo apt-get install g++
+      sudo apt-get install g++-4.9
     condition: in(variables['image.name'], 'ubuntu-16.04')
-    displayName: 'Install g++ for Linux (for SHAP)'
+    displayName: 'Install g++-4.9 for Linux (for SHAP)'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,12 +126,12 @@ jobs:
       LinuxPython35:
         python.version: '3.5'
         image.name: 'ubuntu-16.04'
-      LinuxPython36:
-        python.version: '3.6'
-        image.name: 'ubuntu-16.04'
-      LinuxPython37:
-        python.version: '3.7'
-        image.name: 'ubuntu-16.04'
+#      LinuxPython36:
+#        python.version: '3.6'
+#        image.name: 'ubuntu-16.04'
+#      LinuxPython37:
+#        python.version: '3.7'
+#        image.name: 'ubuntu-16.04'
       WindowsPython35:
         python.version: '3.5'
         image.name: 'windows-2019'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,12 +126,12 @@ jobs:
       LinuxPython35:
         python.version: '3.5'
         image.name: 'ubuntu-16.04'
-#      LinuxPython36:
-#        python.version: '3.6'
-#        image.name: 'ubuntu-16.04'
-#      LinuxPython37:
-#        python.version: '3.7'
-#        image.name: 'ubuntu-16.04'
+      LinuxPython36:
+        python.version: '3.6'
+        image.name: 'ubuntu-16.04'
+      LinuxPython37:
+        python.version: '3.7'
+        image.name: 'ubuntu-16.04'
       WindowsPython35:
         python.version: '3.5'
         image.name: 'windows-2019'
@@ -170,6 +170,10 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
+  - script: |
+      sudo apt-get install g++
+    condition: in(variables['image.name'], 'ubuntu-16.04')
+    displayName: 'Install g++ for Linux (for SHAP)'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,7 +187,7 @@ jobs:
     displayName: 'Install requirements'
   - script: |
       set PATH=%PATH%;%GeckoWebDriver%
-      python -m pytest -vv --runslow --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+      python -m pytest -vv --runslow --runselenium --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
     workingDirectory: src/python
     condition: in(variables['image.name'], 'windows-2019')
     displayName: 'Run pytest (Windows)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,10 +170,6 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
-  - script: |
-      sudo apt-get install g++-4.9
-    condition: in(variables['image.name'], 'ubuntu-16.04')
-    displayName: 'Install g++-4.9 for Linux (for SHAP)'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: |
@@ -186,6 +182,8 @@ jobs:
     condition: in(variables['image.name'], 'macOS-10.13')
     displayName: 'Matplotlib patch for mac.'
   - script: |
+      export LIBRARY_PATH=$LIBRARY_PATH:/opt/hostedtoolcache/Python/3.6.9/x64/lib
+      export LIBRARY_PATH=$LIBRARY_PATH:/opt/hostedtoolcache/Python/3.7.4/x64/lib
       python -m pip install -r dev-requirements.txt
     workingDirectory: src/python
     displayName: 'Install requirements'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,7 +187,7 @@ jobs:
     displayName: 'Install requirements'
   - script: |
       set PATH=%PATH%;%GeckoWebDriver%
-      python -m pytest -vv --runslow --runselenium --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+      python -m pytest -vv --runslow --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
     workingDirectory: src/python
     condition: in(variables['image.name'], 'windows-2019')
     displayName: 'Run pytest (Windows)'

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,8 @@ for arg in "$@"; do
    fi
 done
 
-compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wnull-dereference -Wold-style-cast -Wuseless-cast -Wjump-misses-init -Wdouble-promotion -Wshadow -Wformat=2 -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
+# re-enable these warnings when they are better supported by g++ or clang: -Wduplicated-cond -Wduplicated-branches -Wrestrict 
+compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -Wnull-dereference -Wold-style-cast -Wdouble-promotion -Wshadow -Wformat=2 -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
 
 if [ "$os_type" = "Darwin" ]; then
    # reference on rpath & install_name: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html
@@ -156,7 +157,8 @@ elif [ "$os_type" = "Linux" ]; then
 
    # to cross compile for different architectures x86/x64, run the following command: sudo apt-get install g++-multilib
 
-   compile_linux="$compile_all -Wl,--version-script=\"$root_path/src/core/ebmcore/EbmCoreExports.txt\" -Wl,--exclude-libs,ALL -Wl,--wrap=memcpy \"$root_path/src/core/ebmcore/WrapFunc.cpp\" -static-libgcc -static-libstdc++ -shared"
+   # try moving some of these g++ specific warnings into compile_all if clang eventually supports them
+   compile_linux="$compile_all -Wlogical-op -Wuseless-cast -Wjump-misses-init -Wl,--version-script=\"$root_path/src/core/ebmcore/EbmCoreExports.txt\" -Wl,--exclude-libs,ALL -Wl,--wrap=memcpy \"$root_path/src/core/ebmcore/WrapFunc.cpp\" -static-libgcc -static-libstdc++ -shared"
 
    echo "Creating initial directories"
    [ -d "$root_path/staging" ] || mkdir -p "$root_path/staging"

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ for arg in "$@"; do
    fi
 done
 
-compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
+compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
 
 if [ "$os_type" = "Darwin" ]; then
    # reference on rpath & install_name: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ if [ "$os_type" = "Darwin" ]; then
    # try moving some of these clang specific warnings into compile_all if g++ eventually supports them
    compile_mac="$compile_all -Wnull-dereference -dynamiclib"
 
-   echo "Creating initial directories"
+   printf "%s\n" "Creating initial directories"
    [ -d "$root_path/staging" ] || mkdir -p "$root_path/staging"
    ret_code=$?
    if [ $ret_code -ne 0 ]; then 
@@ -33,7 +33,7 @@ if [ "$os_type" = "Darwin" ]; then
       exit $ret_code
    fi
 
-   echo "Compiling ebmcore with $clang_pp_bin for macOS release|x64"
+   printf "%s\n" "Compiling ebmcore with $clang_pp_bin for macOS release|x64"
    [ -d "$root_path/tmp/clang/intermediate/release/mac/x64/ebmcore" ] || mkdir -p "$root_path/tmp/clang/intermediate/release/mac/x64/ebmcore"
    ret_code=$?
    if [ $ret_code -ne 0 ]; then 
@@ -47,8 +47,8 @@ if [ "$os_type" = "Darwin" ]; then
    compile_command="$clang_pp_bin $compile_mac -m64 -DNDEBUG -install_name @rpath/lib_ebmcore_mac_x64.dylib -o \"$root_path/tmp/clang/bin/release/mac/x64/ebmcore/lib_ebmcore_mac_x64.dylib\" 2>&1"
    compile_out=`eval $compile_command`
    ret_code=$?
-   echo "$compile_out"
-   echo "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x64/ebmcore/ebmcore_release_mac_x64_build_log.txt"
+   printf "%s\n" "$compile_out"
+   printf "%s\n" "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x64/ebmcore/ebmcore_release_mac_x64_build_log.txt"
    if [ $ret_code -ne 0 ]; then 
       exit $ret_code
    fi
@@ -63,7 +63,7 @@ if [ "$os_type" = "Darwin" ]; then
       exit $ret_code
    fi
 
-   echo "Compiling ebmcore with $clang_pp_bin for macOS debug|x64"
+   printf "%s\n" "Compiling ebmcore with $clang_pp_bin for macOS debug|x64"
    [ -d "$root_path/tmp/clang/intermediate/debug/mac/x64/ebmcore" ] || mkdir -p "$root_path/tmp/clang/intermediate/debug/mac/x64/ebmcore"
    ret_code=$?
    if [ $ret_code -ne 0 ]; then 
@@ -77,8 +77,8 @@ if [ "$os_type" = "Darwin" ]; then
    compile_command="$clang_pp_bin $compile_mac -m64 -install_name @rpath/lib_ebmcore_mac_x64_debug.dylib -o \"$root_path/tmp/clang/bin/debug/mac/x64/ebmcore/lib_ebmcore_mac_x64_debug.dylib\" 2>&1"
    compile_out=`eval $compile_command`
    ret_code=$?
-   echo "$compile_out"
-   echo "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x64/ebmcore/ebmcore_debug_mac_x64_build_log.txt"
+   printf "%s\n" "$compile_out"
+   printf "%s\n" "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x64/ebmcore/ebmcore_debug_mac_x64_build_log.txt"
    if [ $ret_code -ne 0 ]; then 
       exit $ret_code
    fi
@@ -94,7 +94,7 @@ if [ "$os_type" = "Darwin" ]; then
    fi
 
    if [ $build_32_bit -eq 1 ]; then
-      echo "Compiling ebmcore with $clang_pp_bin for macOS release|x86"
+      printf "%s\n" "Compiling ebmcore with $clang_pp_bin for macOS release|x86"
       [ -d "$root_path/tmp/clang/intermediate/release/mac/x86/ebmcore" ] || mkdir -p "$root_path/tmp/clang/intermediate/release/mac/x86/ebmcore"
       ret_code=$?
       if [ $ret_code -ne 0 ]; then 
@@ -108,8 +108,8 @@ if [ "$os_type" = "Darwin" ]; then
       compile_command="$clang_pp_bin $compile_mac -m32 -DNDEBUG -install_name @rpath/lib_ebmcore_mac_x86.dylib -o \"$root_path/tmp/clang/bin/release/mac/x86/ebmcore/lib_ebmcore_mac_x86.dylib\" 2>&1"
       compile_out=`eval $compile_command`
       ret_code=$?
-      echo "$compile_out"
-      echo "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x86/ebmcore/ebmcore_release_mac_x86_build_log.txt"
+      printf "%s\n" "$compile_out"
+      printf "%s\n" "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x86/ebmcore/ebmcore_release_mac_x86_build_log.txt"
       if [ $ret_code -ne 0 ]; then 
          exit $ret_code
       fi
@@ -124,7 +124,7 @@ if [ "$os_type" = "Darwin" ]; then
          exit $ret_code
       fi
 
-      echo "Compiling ebmcore with $clang_pp_bin for macOS debug|x86"
+      printf "%s\n" "Compiling ebmcore with $clang_pp_bin for macOS debug|x86"
       [ -d "$root_path/tmp/clang/intermediate/debug/mac/x86/ebmcore" ] || mkdir -p "$root_path/tmp/clang/intermediate/debug/mac/x86/ebmcore"
       ret_code=$?
       if [ $ret_code -ne 0 ]; then 
@@ -138,8 +138,8 @@ if [ "$os_type" = "Darwin" ]; then
       compile_command="$clang_pp_bin $compile_mac -m32 -install_name @rpath/lib_ebmcore_mac_x86_debug.dylib -o \"$root_path/tmp/clang/bin/debug/mac/x86/ebmcore/lib_ebmcore_mac_x86_debug.dylib\" 2>&1"
       compile_out=`eval $compile_command`
       ret_code=$?
-      echo "$compile_out"
-      echo "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x86/ebmcore/ebmcore_debug_mac_x86_build_log.txt"
+      printf "%s\n" "$compile_out"
+      printf "%s\n" "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x86/ebmcore/ebmcore_debug_mac_x86_build_log.txt"
       if [ $ret_code -ne 0 ]; then 
          exit $ret_code
       fi
@@ -161,7 +161,7 @@ elif [ "$os_type" = "Linux" ]; then
    # try moving some of these g++ specific warnings into compile_all if clang eventually supports them
    compile_linux="$compile_all -Wlogical-op -Wl,--version-script=\"$root_path/src/core/ebmcore/EbmCoreExports.txt\" -Wl,--exclude-libs,ALL -Wl,--wrap=memcpy \"$root_path/src/core/ebmcore/WrapFunc.cpp\" -static-libgcc -static-libstdc++ -shared"
 
-   echo "Creating initial directories"
+   printf "%s\n" "Creating initial directories"
    [ -d "$root_path/staging" ] || mkdir -p "$root_path/staging"
    ret_code=$?
    if [ $ret_code -ne 0 ]; then 
@@ -173,7 +173,7 @@ elif [ "$os_type" = "Linux" ]; then
       exit $ret_code
    fi
 
-   echo "Compiling ebmcore with $g_pp_bin for Linux release|x64"
+   printf "%s\n" "Compiling ebmcore with $g_pp_bin for Linux release|x64"
    [ -d "$root_path/tmp/gcc/intermediate/release/linux/x64/ebmcore" ] || mkdir -p "$root_path/tmp/gcc/intermediate/release/linux/x64/ebmcore"
    ret_code=$?
    if [ $ret_code -ne 0 ]; then 
@@ -187,8 +187,8 @@ elif [ "$os_type" = "Linux" ]; then
    compile_command="$g_pp_bin $compile_linux -m64 -DNDEBUG -o \"$root_path/tmp/gcc/bin/release/linux/x64/ebmcore/lib_ebmcore_linux_x64.so\" 2>&1"
    compile_out=`eval $compile_command`
    ret_code=$?
-   echo -n "$compile_out"
-   echo -n "$compile_out" > "$root_path/tmp/gcc/intermediate/release/linux/x64/ebmcore/ebmcore_release_linux_x64_build_log.txt"
+   printf "%s\n" "$compile_out"
+   printf "%s\n" "$compile_out" > "$root_path/tmp/gcc/intermediate/release/linux/x64/ebmcore/ebmcore_release_linux_x64_build_log.txt"
    if [ $ret_code -ne 0 ]; then 
       exit $ret_code
    fi
@@ -203,7 +203,7 @@ elif [ "$os_type" = "Linux" ]; then
       exit $ret_code
    fi
 
-   echo "Compiling ebmcore with $g_pp_bin for Linux debug|x64"
+   printf "%s\n" "Compiling ebmcore with $g_pp_bin for Linux debug|x64"
    [ -d "$root_path/tmp/gcc/intermediate/debug/linux/x64/ebmcore" ] || mkdir -p "$root_path/tmp/gcc/intermediate/debug/linux/x64/ebmcore"
    ret_code=$?
    if [ $ret_code -ne 0 ]; then 
@@ -217,8 +217,8 @@ elif [ "$os_type" = "Linux" ]; then
    compile_command="$g_pp_bin $compile_linux -m64 -o \"$root_path/tmp/gcc/bin/debug/linux/x64/ebmcore/lib_ebmcore_linux_x64_debug.so\" 2>&1"
    compile_out=`eval $compile_command`
    ret_code=$?
-   echo -n "$compile_out"
-   echo -n "$compile_out" > "$root_path/tmp/gcc/intermediate/debug/linux/x64/ebmcore/ebmcore_debug_linux_x64_build_log.txt"
+   printf "%s\n" "$compile_out"
+   printf "%s\n" "$compile_out" > "$root_path/tmp/gcc/intermediate/debug/linux/x64/ebmcore/ebmcore_debug_linux_x64_build_log.txt"
    if [ $ret_code -ne 0 ]; then 
       exit $ret_code
    fi
@@ -234,7 +234,7 @@ elif [ "$os_type" = "Linux" ]; then
    fi
 
    if [ $build_32_bit -eq 1 ]; then
-      echo "Compiling ebmcore with $g_pp_bin for Linux release|x86"
+      printf "%s\n" "Compiling ebmcore with $g_pp_bin for Linux release|x86"
       [ -d "$root_path/tmp/gcc/intermediate/release/linux/x86/ebmcore" ] || mkdir -p "$root_path/tmp/gcc/intermediate/release/linux/x86/ebmcore"
       ret_code=$?
       if [ $ret_code -ne 0 ]; then 
@@ -248,8 +248,8 @@ elif [ "$os_type" = "Linux" ]; then
       compile_command="$g_pp_bin $compile_linux -m32 -DNDEBUG -o \"$root_path/tmp/gcc/bin/release/linux/x86/ebmcore/lib_ebmcore_linux_x86.so\" 2>&1"
       compile_out=`eval $compile_command`
       ret_code=$?
-      echo -n "$compile_out"
-      echo -n "$compile_out" > "$root_path/tmp/gcc/intermediate/release/linux/x86/ebmcore/ebmcore_release_linux_x86_build_log.txt"
+      printf "%s\n" "$compile_out"
+      printf "%s\n" "$compile_out" > "$root_path/tmp/gcc/intermediate/release/linux/x86/ebmcore/ebmcore_release_linux_x86_build_log.txt"
       if [ $ret_code -ne 0 ]; then 
          exit $ret_code
       fi
@@ -264,7 +264,7 @@ elif [ "$os_type" = "Linux" ]; then
          exit $ret_code
       fi
 
-      echo "Compiling ebmcore with $g_pp_bin for Linux debug|x86"
+      printf "%s\n" "Compiling ebmcore with $g_pp_bin for Linux debug|x86"
       [ -d "$root_path/tmp/gcc/intermediate/debug/linux/x86/ebmcore" ] || mkdir -p "$root_path/tmp/gcc/intermediate/debug/linux/x86/ebmcore"
       ret_code=$?
       if [ $ret_code -ne 0 ]; then 
@@ -278,8 +278,8 @@ elif [ "$os_type" = "Linux" ]; then
       compile_command="$g_pp_bin $compile_linux -m32 -o \"$root_path/tmp/gcc/bin/debug/linux/x86/ebmcore/lib_ebmcore_linux_x86_debug.so\" 2>&1"
       compile_out=`eval $compile_command`
       ret_code=$?
-      echo -n "$compile_out"
-      echo -n "$compile_out" > "$root_path/tmp/gcc/intermediate/debug/linux/x86/ebmcore/ebmcore_debug_linux_x86_build_log.txt"
+      printf "%s\n" "$compile_out"
+      printf "%s\n" "$compile_out" > "$root_path/tmp/gcc/intermediate/debug/linux/x86/ebmcore/ebmcore_debug_linux_x86_build_log.txt"
       if [ $ret_code -ne 0 ]; then 
          exit $ret_code
       fi
@@ -295,6 +295,6 @@ elif [ "$os_type" = "Linux" ]; then
       fi
    fi
 else
-   echo "OS $os_type not recognized.  We support $clang_pp_bin on macOS and $g_pp_bin on Linux"
+   printf "%s\n" "OS $os_type not recognized.  We support $clang_pp_bin on macOS and $g_pp_bin on Linux"
    exit 1
 fi

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ for arg in "$@"; do
    fi
 done
 
-compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
+compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
 
 if [ "$os_type" = "Darwin" ]; then
    # reference on rpath & install_name: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html

--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,13 @@ for arg in "$@"; do
 done
 
 # re-enable these warnings when they are better supported by g++ or clang: -Wduplicated-cond -Wduplicated-branches -Wrestrict 
-compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -Wnull-dereference -Wold-style-cast -Wdouble-promotion -Wshadow -Wformat=2 -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
+compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -Wold-style-cast -Wdouble-promotion -Wshadow -Wformat=2 -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
 
 if [ "$os_type" = "Darwin" ]; then
    # reference on rpath & install_name: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html
 
-   compile_mac="$compile_all -dynamiclib"
+   # try moving some of these clang specific warnings into compile_all if g++ eventually supports them
+   compile_mac="$compile_all -Wnull-dereference -dynamiclib"
 
    echo "Creating initial directories"
    [ -d "$root_path/staging" ] || mkdir -p "$root_path/staging"

--- a/build.sh
+++ b/build.sh
@@ -159,7 +159,7 @@ elif [ "$os_type" = "Linux" ]; then
    # to cross compile for different architectures x86/x64, run the following command: sudo apt-get install g++-multilib
 
    # try moving some of these g++ specific warnings into compile_all if clang eventually supports them
-   compile_linux="$compile_all -Wlogical-op -Wuseless-cast -Wjump-misses-init -Wl,--version-script=\"$root_path/src/core/ebmcore/EbmCoreExports.txt\" -Wl,--exclude-libs,ALL -Wl,--wrap=memcpy \"$root_path/src/core/ebmcore/WrapFunc.cpp\" -static-libgcc -static-libstdc++ -shared"
+   compile_linux="$compile_all -Wlogical-op -Wl,--version-script=\"$root_path/src/core/ebmcore/EbmCoreExports.txt\" -Wl,--exclude-libs,ALL -Wl,--wrap=memcpy \"$root_path/src/core/ebmcore/WrapFunc.cpp\" -static-libgcc -static-libstdc++ -shared"
 
    echo "Creating initial directories"
    [ -d "$root_path/staging" ] || mkdir -p "$root_path/staging"

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ for arg in "$@"; do
    fi
 done
 
-compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
+compile_all="\"$root_path/src/core/ebmcore/DataSetByAttribute.cpp\" \"$root_path/src/core/ebmcore/DataSetByAttributeCombination.cpp\" \"$root_path/src/core/ebmcore/InteractionDetection.cpp\" \"$root_path/src/core/ebmcore/Logging.cpp\" \"$root_path/src/core/ebmcore/SamplingWithReplacement.cpp\" \"$root_path/src/core/ebmcore/Training.cpp\" -I\"$root_path/src/core/ebmcore\" -I\"$root_path/src/core/inc\" -Wall -Wextra -Wno-parentheses -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wnull-dereference -Wold-style-cast -Wuseless-cast -Wjump-misses-init -Wdouble-promotion -Wshadow -Wformat=2 -std=c++11 -fpermissive -fvisibility=hidden -fvisibility-inlines-hidden -O3 -march=core2 -DEBMCORE_EXPORTS -fpic"
 
 if [ "$os_type" = "Darwin" ]; then
    # reference on rpath & install_name: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html
@@ -45,8 +45,8 @@ if [ "$os_type" = "Darwin" ]; then
    compile_command="$clang_pp_bin $compile_mac -m64 -DNDEBUG -install_name @rpath/lib_ebmcore_mac_x64.dylib -o \"$root_path/tmp/clang/bin/release/mac/x64/ebmcore/lib_ebmcore_mac_x64.dylib\" 2>&1"
    compile_out=`eval $compile_command`
    ret_code=$?
-   echo -n "$compile_out"
-   echo -n "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x64/ebmcore/ebmcore_release_mac_x64_build_log.txt"
+   echo "$compile_out"
+   echo "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x64/ebmcore/ebmcore_release_mac_x64_build_log.txt"
    if [ $ret_code -ne 0 ]; then 
       exit $ret_code
    fi
@@ -75,8 +75,8 @@ if [ "$os_type" = "Darwin" ]; then
    compile_command="$clang_pp_bin $compile_mac -m64 -install_name @rpath/lib_ebmcore_mac_x64_debug.dylib -o \"$root_path/tmp/clang/bin/debug/mac/x64/ebmcore/lib_ebmcore_mac_x64_debug.dylib\" 2>&1"
    compile_out=`eval $compile_command`
    ret_code=$?
-   echo -n "$compile_out"
-   echo -n "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x64/ebmcore/ebmcore_debug_mac_x64_build_log.txt"
+   echo "$compile_out"
+   echo "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x64/ebmcore/ebmcore_debug_mac_x64_build_log.txt"
    if [ $ret_code -ne 0 ]; then 
       exit $ret_code
    fi
@@ -106,8 +106,8 @@ if [ "$os_type" = "Darwin" ]; then
       compile_command="$clang_pp_bin $compile_mac -m32 -DNDEBUG -install_name @rpath/lib_ebmcore_mac_x86.dylib -o \"$root_path/tmp/clang/bin/release/mac/x86/ebmcore/lib_ebmcore_mac_x86.dylib\" 2>&1"
       compile_out=`eval $compile_command`
       ret_code=$?
-      echo -n "$compile_out"
-      echo -n "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x86/ebmcore/ebmcore_release_mac_x86_build_log.txt"
+      echo "$compile_out"
+      echo "$compile_out" > "$root_path/tmp/clang/intermediate/release/mac/x86/ebmcore/ebmcore_release_mac_x86_build_log.txt"
       if [ $ret_code -ne 0 ]; then 
          exit $ret_code
       fi
@@ -136,8 +136,8 @@ if [ "$os_type" = "Darwin" ]; then
       compile_command="$clang_pp_bin $compile_mac -m32 -install_name @rpath/lib_ebmcore_mac_x86_debug.dylib -o \"$root_path/tmp/clang/bin/debug/mac/x86/ebmcore/lib_ebmcore_mac_x86_debug.dylib\" 2>&1"
       compile_out=`eval $compile_command`
       ret_code=$?
-      echo -n "$compile_out"
-      echo -n "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x86/ebmcore/ebmcore_debug_mac_x86_build_log.txt"
+      echo "$compile_out"
+      echo "$compile_out" > "$root_path/tmp/clang/intermediate/debug/mac/x86/ebmcore/ebmcore_debug_mac_x86_build_log.txt"
       if [ $ret_code -ne 0 ]; then 
          exit $ret_code
       fi

--- a/src/core/TestCoreApi/PrecompiledHeaderTestCoreApi.h
+++ b/src/core/TestCoreApi/PrecompiledHeaderTestCoreApi.h
@@ -2,4 +2,7 @@
 // Licensed under the MIT license.
 // Author: Paul Koch <code@koch.ninja>
 
+#include <string>
+#include <stdio.h>
 #include <iostream>
+#include <vector>

--- a/src/core/TestCoreApi/PrecompiledHeaderTestCoreApi.h
+++ b/src/core/TestCoreApi/PrecompiledHeaderTestCoreApi.h
@@ -6,3 +6,4 @@
 #include <stdio.h>
 #include <iostream>
 #include <vector>
+#include <algorithm>

--- a/src/core/TestCoreApi/PrecompiledHeaderTestCoreApi.h
+++ b/src/core/TestCoreApi/PrecompiledHeaderTestCoreApi.h
@@ -7,3 +7,4 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cmath>

--- a/src/core/TestCoreApi/TestCoreApi.cpp
+++ b/src/core/TestCoreApi/TestCoreApi.cpp
@@ -383,6 +383,313 @@ TEST_CASE("AttributeCombination with zero attributes, Interaction, multiclass") 
    FreeInteraction(pEbmInteraction);
 }
 
+TEST_CASE("AttributeCombination with one attribute with one state, Training, regression") {
+   constexpr IntegerDataType randomSeed = 42;
+   constexpr size_t cVectorLength = 1;
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinations = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 1;
+   constexpr size_t cTrainingCases = 1;
+   constexpr size_t cValidationCases = 1;
+   constexpr IntegerDataType countInnerBags = 0;
+   constexpr IntegerDataType countIterations = 2;
+   constexpr FractionalDataType learningRate = 0.01;
+   constexpr IntegerDataType countTreeSplitsMax = 2;
+   constexpr IntegerDataType countCasesRequiredForSplitParentMin = 2;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   EbmAttributeCombination combinations[std::max(std::size_t { 1 }, cAttributeCombinations)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   FractionalDataType trainingTargets[std::max(std::size_t { 1 }, cTrainingCases)];
+   IntegerDataType trainingData[std::max(std::size_t { 1 }, cTrainingCases * cAttributes)];
+   FractionalDataType trainingPredictionScores[std::max(std::size_t { 1 }, cTrainingCases * cVectorLength)];
+   FractionalDataType validationTargets[std::max(std::size_t { 1 }, cValidationCases)];
+   IntegerDataType validationData[std::max(std::size_t { 1 }, cValidationCases * cAttributes)];
+   FractionalDataType validationPredictionScores[std::max(std::size_t { 1 }, cValidationCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 1;
+   attributes[0].hasMissing = 0;
+
+   combinations[0].countAttributesInCombination = 1;
+
+   combinationIndexes[0] = 0;
+
+   trainingTargets[0] = 10.5;
+   trainingData[0] = 0;
+   trainingPredictionScores[0] = 0;
+
+   validationTargets[0] = 10.4;
+   validationData[0] = 0;
+   validationPredictionScores[0] = 0;
+
+   PEbmTraining pEbmTraining = InitializeTrainingRegression(randomSeed, cAttributes, attributes, cAttributeCombinations, combinations, combinationIndexes, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores, countInnerBags);
+
+   FractionalDataType validationMetricReturn;
+   IntegerDataType result;
+   int count = countIterations;
+   while(count--) {
+      result = TrainingStep(pEbmTraining, 0, learningRate, countTreeSplitsMax, countCasesRequiredForSplitParentMin, nullptr, nullptr, &validationMetricReturn);
+      CHECK(0 == result);
+      if(0 != result) {
+         return;
+      }
+      if(1 == count) {
+         CHECK_APPROX(validationMetricReturn, 10.295000000000000);
+      } else if(0 == count) {
+         CHECK_APPROX(validationMetricReturn, 10.191050000000001);
+      }
+   }
+   double * pModel = GetCurrentModel(pEbmTraining, 0);
+   double modelValue = pModel[0];
+   CHECK_APPROX(modelValue, 0.20895000000000000);
+   FreeTraining(pEbmTraining);
+}
+
+TEST_CASE("AttributeCombination with one attribute with one state, Training, Binary") {
+   constexpr IntegerDataType randomSeed = 42;
+   constexpr IntegerDataType countTargetStates = 2;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinations = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 1;
+   constexpr size_t cTrainingCases = 1;
+   constexpr size_t cValidationCases = 1;
+   constexpr IntegerDataType countInnerBags = 0;
+   constexpr IntegerDataType countIterations = 2;
+   constexpr FractionalDataType learningRate = 0.01;
+   constexpr IntegerDataType countTreeSplitsMax = 2;
+   constexpr IntegerDataType countCasesRequiredForSplitParentMin = 2;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   EbmAttributeCombination combinations[std::max(std::size_t { 1 }, cAttributeCombinations)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType trainingTargets[std::max(std::size_t { 1 }, cTrainingCases)];
+   IntegerDataType trainingData[std::max(std::size_t { 1 }, cTrainingCases * cAttributes)];
+   FractionalDataType trainingPredictionScores[std::max(std::size_t { 1 }, cTrainingCases * cVectorLength)];
+   IntegerDataType validationTargets[std::max(std::size_t { 1 }, cValidationCases)];
+   IntegerDataType validationData[std::max(std::size_t { 1 }, cValidationCases * cAttributes)];
+   FractionalDataType validationPredictionScores[std::max(std::size_t { 1 }, cValidationCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 1;
+   attributes[0].hasMissing = 0;
+
+   combinations[0].countAttributesInCombination = 1;
+
+   combinationIndexes[0] = 0;
+
+   trainingTargets[0] = 0;
+   trainingData[0] = 0;
+   trainingPredictionScores[0] = 0;
+
+   validationTargets[0] = 0;
+   validationData[0] = 0;
+   validationPredictionScores[0] = 0;
+
+   PEbmTraining pEbmTraining = InitializeTrainingClassification(randomSeed, cAttributes, attributes, cAttributeCombinations, combinations, combinationIndexes, countTargetStates, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores, countInnerBags);
+
+   FractionalDataType validationMetricReturn;
+   IntegerDataType result;
+   int count = countIterations;
+   while(count--) {
+      result = TrainingStep(pEbmTraining, 0, learningRate, countTreeSplitsMax, countCasesRequiredForSplitParentMin, nullptr, nullptr, &validationMetricReturn);
+      CHECK(0 == result);
+      if(0 != result) {
+         return;
+      }
+      if(1 == count) {
+         CHECK_APPROX(validationMetricReturn, 0.68319717972663419);
+      } else if(0 == count) {
+         CHECK_APPROX(validationMetricReturn, 0.67344419889200957);
+      }
+   }
+   double * pModel = GetCurrentModel(pEbmTraining, 0);
+   double modelValue = pModel[0];
+   CHECK_APPROX(modelValue, -0.039801986733067563);
+   FreeTraining(pEbmTraining);
+}
+
+TEST_CASE("AttributeCombination with one attribute with one state, Training, multiclass") {
+   constexpr IntegerDataType randomSeed = 42;
+   constexpr IntegerDataType countTargetStates = 3;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinations = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 1;
+   constexpr size_t cTrainingCases = 1;
+   constexpr size_t cValidationCases = 1;
+   constexpr IntegerDataType countInnerBags = 0;
+   constexpr IntegerDataType countIterations = 2;
+   constexpr FractionalDataType learningRate = 0.01;
+   constexpr IntegerDataType countTreeSplitsMax = 2;
+   constexpr IntegerDataType countCasesRequiredForSplitParentMin = 2;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   EbmAttributeCombination combinations[std::max(std::size_t { 1 }, cAttributeCombinations)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType trainingTargets[std::max(std::size_t { 1 }, cTrainingCases)];
+   IntegerDataType trainingData[std::max(std::size_t { 1 }, cTrainingCases * cAttributes)];
+   FractionalDataType trainingPredictionScores[std::max(std::size_t { 1 }, cTrainingCases * cVectorLength)];
+   IntegerDataType validationTargets[std::max(std::size_t { 1 }, cValidationCases)];
+   IntegerDataType validationData[std::max(std::size_t { 1 }, cValidationCases * cAttributes)];
+   FractionalDataType validationPredictionScores[std::max(std::size_t { 1 }, cValidationCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 1;
+   attributes[0].hasMissing = 0;
+
+   combinations[0].countAttributesInCombination = 1;
+
+   combinationIndexes[0] = 0;
+
+   trainingTargets[0] = 0;
+   trainingData[0] = 0;
+   trainingPredictionScores[0] = 0;
+   trainingPredictionScores[1] = 0;
+   trainingPredictionScores[2] = 0;
+
+   validationTargets[0] = 0;
+   validationData[0] = 0;
+   validationPredictionScores[0] = 0;
+   validationPredictionScores[1] = 0;
+   validationPredictionScores[2] = 0;
+
+   PEbmTraining pEbmTraining = InitializeTrainingClassification(randomSeed, cAttributes, attributes, cAttributeCombinations, combinations, combinationIndexes, countTargetStates, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores, countInnerBags);
+
+   FractionalDataType validationMetricReturn;
+   IntegerDataType result;
+   int count = countIterations;
+   while(count--) {
+      result = TrainingStep(pEbmTraining, 0, learningRate, countTreeSplitsMax, countCasesRequiredForSplitParentMin, nullptr, nullptr, &validationMetricReturn);
+      CHECK(0 == result);
+      if(0 != result) {
+         return;
+      }
+      if(1 == count) {
+         CHECK_APPROX(validationMetricReturn, 1.0688384008227103);
+      } else if(0 == count) {
+         CHECK_APPROX(validationMetricReturn, 1.0401627411809615);
+      }
+   }
+   double * pModel = GetCurrentModel(pEbmTraining, 0);
+   double modelValue1 = pModel[0];
+   double modelValue2 = pModel[1];
+   double modelValue3 = pModel[2];
+   CHECK_APPROX(modelValue1, 0.059119949636662006);
+   CHECK_APPROX(modelValue2, -0.029887518980531450);
+   CHECK_APPROX(modelValue3, -0.029887518980531450);
+   FreeTraining(pEbmTraining);
+}
+
+TEST_CASE("AttributeCombination with one attribute with one state, Interaction, regression") {
+   constexpr size_t cVectorLength = 1;
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 1;
+   constexpr size_t cCases = 1;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   FractionalDataType targets[std::max(std::size_t { 1 }, cCases)];
+   IntegerDataType data[std::max(std::size_t { 1 }, cCases * cAttributes)];
+   FractionalDataType predictionScores[std::max(std::size_t { 1 }, cCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 1;
+   attributes[0].hasMissing = 0;
+
+   combinationIndexes[0] = 0;
+
+   targets[0] = 10.5;
+   data[0] = 0;
+   predictionScores[0] = 0;
+
+   PEbmInteraction pEbmInteraction = InitializeInteractionRegression(cAttributes, attributes, cCases, targets, data, predictionScores);
+
+   FractionalDataType metricReturn;
+   IntegerDataType result;
+   result = GetInteractionScore(pEbmInteraction, cAttributeCombinationsIndexes, combinationIndexes, &metricReturn);
+   CHECK(0 == result);
+   if(0 != result) {
+      return;
+   }
+   CHECK(0 == metricReturn);
+   FreeInteraction(pEbmInteraction);
+}
+
+TEST_CASE("AttributeCombination with one attribute with one state, Interaction, Binary") {
+   constexpr IntegerDataType countTargetStates = 2;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 1;
+   constexpr size_t cCases = 1;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType targets[std::max(std::size_t { 1 }, cCases)];
+   IntegerDataType data[std::max(std::size_t { 1 }, cCases * cAttributes)];
+   FractionalDataType predictionScores[std::max(std::size_t { 1 }, cCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 1;
+   attributes[0].hasMissing = 0;
+
+   combinationIndexes[0] = 0;
+
+   targets[0] = 0;
+   data[0] = 0;
+   predictionScores[0] = 0;
+
+   PEbmInteraction pEbmInteraction = InitializeInteractionClassification(cAttributes, attributes, countTargetStates, cCases, targets, data, predictionScores);
+
+   FractionalDataType metricReturn;
+   IntegerDataType result;
+   result = GetInteractionScore(pEbmInteraction, cAttributeCombinationsIndexes, combinationIndexes, &metricReturn);
+   CHECK(0 == result);
+   if(0 != result) {
+      return;
+   }
+   CHECK(0 == metricReturn);
+   FreeInteraction(pEbmInteraction);
+}
+
+TEST_CASE("AttributeCombination with one attribute with one state, Interaction, multiclass") {
+   constexpr IntegerDataType countTargetStates = 3;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 1;
+   constexpr size_t cCases = 1;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType targets[std::max(std::size_t { 1 }, cCases)];
+   IntegerDataType data[std::max(std::size_t { 1 }, cCases * cAttributes)];
+   FractionalDataType predictionScores[std::max(std::size_t { 1 }, cCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 1;
+   attributes[0].hasMissing = 0;
+
+   combinationIndexes[0] = 0;
+
+   targets[0] = 0;
+   data[0] = 0;
+   predictionScores[0] = 0;
+   predictionScores[1] = 0;
+   predictionScores[2] = 0;
+
+   PEbmInteraction pEbmInteraction = InitializeInteractionClassification(cAttributes, attributes, countTargetStates, cCases, targets, data, predictionScores);
+
+   FractionalDataType metricReturn;
+   IntegerDataType result;
+   result = GetInteractionScore(pEbmInteraction, cAttributeCombinationsIndexes, combinationIndexes, &metricReturn);
+   CHECK(0 == result);
+   if(0 != result) {
+      return;
+   }
+   CHECK(0 == metricReturn);
+   FreeInteraction(pEbmInteraction);
+}
 
 void EBMCORE_CALLING_CONVENTION LogMessage(signed char traceLevel, const char * message) {
    printf("%d - %s\n", traceLevel, message);

--- a/src/core/TestCoreApi/TestCoreApi.cpp
+++ b/src/core/TestCoreApi/TestCoreApi.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <vector>
+#include <algorithm>
 
 #include "ebmcore.h"
 
@@ -52,27 +53,335 @@ inline int RegisterTestHidden(const TestCaseHidden& testCaseHidden) {
    static int CONCATENATE_TOKENS(UNUSED_INTEGER_HIDDEN_, __LINE__) = RegisterTestHidden(TestCaseHidden(&CONCATENATE_TOKENS(TEST_FUNCTION_HIDDEN_, __LINE__), description)); \
    static void CONCATENATE_TOKENS(TEST_FUNCTION_HIDDEN_, __LINE__)(TestCaseHidden& testCaseHidden)
 
+inline bool IsApproxEqual(const double value, const double expected, const double percentage) {
+   return std::abs(expected - value) < std::abs(expected * percentage);
+}
+
 #define CHECK(expression) \
    do { \
       const bool bFailedHidden = !(expression); \
       if(bFailedHidden) { \
-         std::cout << " FAILED on \"" #expression << "\""; \
+         std::cout << " FAILED on \"" #expression "\""; \
          testCaseHidden.m_bPassed = false; \
       } \
    } while((void)0, 0)
 
-TEST_CASE("test 1") {
-   CHECK(true);
+#define CHECK_APPROX(value, expected) \
+   do { \
+      const double valueHidden = (value); \
+      const bool bApproxEqualHidden = IsApproxEqual(valueHidden, (expected), 0.01); \
+      if(!bApproxEqualHidden) { \
+         std::cout << " FAILED on \"" #value "(" << valueHidden << ") approx " #expected "\""; \
+         testCaseHidden.m_bPassed = false; \
+      } \
+   } while((void)0, 0)
+
+
+
+constexpr size_t GetVectorLength(size_t cTargetStates) {
+#ifdef TREAT_BINARY_AS_MULTICLASS
+   return cTargetStates <= 1 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+#else // TREAT_BINARY_AS_MULTICLASS
+   return cTargetStates <= 2 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+#endif // TREAT_BINARY_AS_MULTICLASS
 }
 
-TEST_CASE("test 2") {
-   CHECK(true);
-   CHECK(true);
+TEST_CASE("AttributeCombination with zero attributes, Training, regression") {
+   constexpr IntegerDataType randomSeed = 42;
+   constexpr size_t cVectorLength = 1;
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinations = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 0;
+   constexpr size_t cTrainingCases = 1;
+   constexpr size_t cValidationCases = 1;
+   constexpr IntegerDataType countInnerBags = 0;
+   constexpr IntegerDataType countIterations = 2;
+   constexpr FractionalDataType learningRate = 0.01;
+   constexpr IntegerDataType countTreeSplitsMax = 2;
+   constexpr IntegerDataType countCasesRequiredForSplitParentMin = 2;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   EbmAttributeCombination combinations[std::max(std::size_t { 1 }, cAttributeCombinations)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   FractionalDataType trainingTargets[std::max(std::size_t { 1 }, cTrainingCases)];
+   IntegerDataType trainingData[std::max(std::size_t { 1 }, cTrainingCases * cAttributes)];
+   FractionalDataType trainingPredictionScores[std::max(std::size_t { 1 }, cTrainingCases * cVectorLength)];
+   FractionalDataType validationTargets[std::max(std::size_t { 1 }, cValidationCases)];
+   IntegerDataType validationData[std::max(std::size_t { 1 }, cValidationCases * cAttributes)];
+   FractionalDataType validationPredictionScores[std::max(std::size_t { 1 }, cValidationCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 2;
+   attributes[0].hasMissing = 0;
+
+   combinations[0].countAttributesInCombination = 0;
+
+   trainingTargets[0] = 10.5;
+   trainingData[0] = 0;
+   trainingPredictionScores[0] = 0;
+
+   validationTargets[0] = 10.4;
+   validationData[0] = 0;
+   validationPredictionScores[0] = 0;
+
+   PEbmTraining pEbmTraining = InitializeTrainingRegression(randomSeed, cAttributes, attributes, cAttributeCombinations, combinations, combinationIndexes, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores, countInnerBags);
+
+   FractionalDataType validationMetricReturn;
+   IntegerDataType result;
+   int count = countIterations;
+   while(count--) {
+      result = TrainingStep(pEbmTraining, 0, learningRate, countTreeSplitsMax, countCasesRequiredForSplitParentMin, nullptr, nullptr, &validationMetricReturn);
+      CHECK(0 == result);
+      if(0 != result) {
+         return;
+      }
+      if(1 == count) {
+         CHECK_APPROX(validationMetricReturn, 10.295000000000000);
+      } else if(0 == count) {
+         CHECK_APPROX(validationMetricReturn, 10.191050000000001);
+      }
+   }
+   double * pModel = GetCurrentModel(pEbmTraining, 0);
+   double modelValue = pModel[0];
+   CHECK_APPROX(modelValue, 0.20895000000000000);
+   FreeTraining(pEbmTraining);
 }
 
-TEST_CASE("test 3") {
-   CHECK(true);
+TEST_CASE("AttributeCombination with zero attributes, Training, Binary") {
+   constexpr IntegerDataType randomSeed = 42;
+   constexpr IntegerDataType countTargetStates = 2;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinations = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 0;
+   constexpr size_t cTrainingCases = 1;
+   constexpr size_t cValidationCases = 1;
+   constexpr IntegerDataType countInnerBags = 0;
+   constexpr IntegerDataType countIterations = 2;
+   constexpr FractionalDataType learningRate = 0.01;
+   constexpr IntegerDataType countTreeSplitsMax = 2;
+   constexpr IntegerDataType countCasesRequiredForSplitParentMin = 2;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   EbmAttributeCombination combinations[std::max(std::size_t { 1 }, cAttributeCombinations)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType trainingTargets[std::max(std::size_t { 1 }, cTrainingCases)];
+   IntegerDataType trainingData[std::max(std::size_t { 1 }, cTrainingCases * cAttributes)];
+   FractionalDataType trainingPredictionScores[std::max(std::size_t { 1 }, cTrainingCases * cVectorLength)];
+   IntegerDataType validationTargets[std::max(std::size_t { 1 }, cValidationCases)];
+   IntegerDataType validationData[std::max(std::size_t { 1 }, cValidationCases * cAttributes)];
+   FractionalDataType validationPredictionScores[std::max(std::size_t { 1 }, cValidationCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 2;
+   attributes[0].hasMissing = 0;
+
+   combinations[0].countAttributesInCombination = 0;
+
+   trainingTargets[0] = 0;
+   trainingData[0] = 0;
+   trainingPredictionScores[0] = 0;
+
+   validationTargets[0] = 0;
+   validationData[0] = 0;
+   validationPredictionScores[0] = 0;
+
+   PEbmTraining pEbmTraining = InitializeTrainingClassification(randomSeed, cAttributes, attributes, cAttributeCombinations, combinations, combinationIndexes, countTargetStates, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores, countInnerBags);
+
+   FractionalDataType validationMetricReturn;
+   IntegerDataType result;
+   int count = countIterations;
+   while(count--) {
+      result = TrainingStep(pEbmTraining, 0, learningRate, countTreeSplitsMax, countCasesRequiredForSplitParentMin, nullptr, nullptr, &validationMetricReturn);
+      CHECK(0 == result);
+      if(0 != result) {
+         return;
+      }
+      if(1 == count) {
+         CHECK_APPROX(validationMetricReturn, 0.68319717972663419);
+      } else if(0 == count) {
+         CHECK_APPROX(validationMetricReturn, 0.67344419889200957);
+      }
+   }
+   double * pModel = GetCurrentModel(pEbmTraining, 0);
+   double modelValue = pModel[0];
+   CHECK_APPROX(modelValue, -0.039801986733067563);
+   FreeTraining(pEbmTraining);
 }
+
+TEST_CASE("AttributeCombination with zero attributes, Training, multiclass") {
+   constexpr IntegerDataType randomSeed = 42;
+   constexpr IntegerDataType countTargetStates = 3;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinations = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 0;
+   constexpr size_t cTrainingCases = 1;
+   constexpr size_t cValidationCases = 1;
+   constexpr IntegerDataType countInnerBags = 0;
+   constexpr IntegerDataType countIterations = 2;
+   constexpr FractionalDataType learningRate = 0.01;
+   constexpr IntegerDataType countTreeSplitsMax = 2;
+   constexpr IntegerDataType countCasesRequiredForSplitParentMin = 2;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   EbmAttributeCombination combinations[std::max(std::size_t { 1 }, cAttributeCombinations)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType trainingTargets[std::max(std::size_t { 1 }, cTrainingCases)];
+   IntegerDataType trainingData[std::max(std::size_t { 1 }, cTrainingCases * cAttributes)];
+   FractionalDataType trainingPredictionScores[std::max(std::size_t { 1 }, cTrainingCases * cVectorLength)];
+   IntegerDataType validationTargets[std::max(std::size_t { 1 }, cValidationCases)];
+   IntegerDataType validationData[std::max(std::size_t { 1 }, cValidationCases * cAttributes)];
+   FractionalDataType validationPredictionScores[std::max(std::size_t { 1 }, cValidationCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 2;
+   attributes[0].hasMissing = 0;
+
+   combinations[0].countAttributesInCombination = 0;
+
+   trainingTargets[0] = 0;
+   trainingData[0] = 0;
+   trainingPredictionScores[0] = 0;
+   trainingPredictionScores[1] = 0;
+   trainingPredictionScores[2] = 0;
+
+   validationTargets[0] = 0;
+   validationData[0] = 0;
+   validationPredictionScores[0] = 0;
+   validationPredictionScores[1] = 0;
+   validationPredictionScores[2] = 0;
+
+   PEbmTraining pEbmTraining = InitializeTrainingClassification(randomSeed, cAttributes, attributes, cAttributeCombinations, combinations, combinationIndexes, countTargetStates, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores, countInnerBags);
+
+   FractionalDataType validationMetricReturn;
+   IntegerDataType result;
+   int count = countIterations;
+   while(count--) {
+      result = TrainingStep(pEbmTraining, 0, learningRate, countTreeSplitsMax, countCasesRequiredForSplitParentMin, nullptr, nullptr, &validationMetricReturn);
+      CHECK(0 == result);
+      if(0 != result) {
+         return;
+      }
+      if(1 == count) {
+         CHECK_APPROX(validationMetricReturn, 1.0688384008227103);
+      } else if(0 == count) {
+         CHECK_APPROX(validationMetricReturn, 1.0401627411809615);
+      }
+   }
+   double * pModel = GetCurrentModel(pEbmTraining, 0);
+   double modelValue1 = pModel[0];
+   double modelValue2 = pModel[1];
+   double modelValue3 = pModel[2];
+   CHECK_APPROX(modelValue1, 0.059119949636662006);
+   CHECK_APPROX(modelValue2, -0.029887518980531450);
+   CHECK_APPROX(modelValue3, -0.029887518980531450);
+   FreeTraining(pEbmTraining);
+}
+
+TEST_CASE("AttributeCombination with zero attributes, Interaction, regression") {
+   constexpr size_t cVectorLength = 1;
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 0;
+   constexpr size_t cCases = 1;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   FractionalDataType targets[std::max(std::size_t { 1 }, cCases)];
+   IntegerDataType data[std::max(std::size_t { 1 }, cCases * cAttributes)];
+   FractionalDataType predictionScores[std::max(std::size_t { 1 }, cCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 2;
+   attributes[0].hasMissing = 0;
+
+   targets[0] = 10.5;
+   data[0] = 0;
+   predictionScores[0] = 0;
+
+   PEbmInteraction pEbmInteraction = InitializeInteractionRegression(cAttributes, attributes, cCases, targets, data, predictionScores);
+
+   FractionalDataType metricReturn;
+   IntegerDataType result;
+   result = GetInteractionScore(pEbmInteraction, cAttributeCombinationsIndexes, combinationIndexes, &metricReturn);
+   CHECK(0 == result);
+   if(0 != result) {
+      return;
+   }
+   CHECK(0 == metricReturn);
+   FreeInteraction(pEbmInteraction);
+}
+
+TEST_CASE("AttributeCombination with zero attributes, Interaction, Binary") {
+   constexpr IntegerDataType countTargetStates = 2;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 0;
+   constexpr size_t cCases = 1;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType targets[std::max(std::size_t { 1 }, cCases)];
+   IntegerDataType data[std::max(std::size_t { 1 }, cCases * cAttributes)];
+   FractionalDataType predictionScores[std::max(std::size_t { 1 }, cCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 2;
+   attributes[0].hasMissing = 0;
+
+   targets[0] = 0;
+   data[0] = 0;
+   predictionScores[0] = 0;
+
+   PEbmInteraction pEbmInteraction = InitializeInteractionClassification(cAttributes, attributes, countTargetStates, cCases, targets, data, predictionScores);
+
+   FractionalDataType metricReturn;
+   IntegerDataType result;
+   result = GetInteractionScore(pEbmInteraction, cAttributeCombinationsIndexes, combinationIndexes, &metricReturn);
+   CHECK(0 == result);
+   if(0 != result) {
+      return;
+   }
+   CHECK(0 == metricReturn);
+   FreeInteraction(pEbmInteraction);
+}
+
+TEST_CASE("AttributeCombination with zero attributes, Interaction, multiclass") {
+   constexpr IntegerDataType countTargetStates = 3;
+   constexpr size_t cVectorLength = GetVectorLength(countTargetStates);
+   constexpr size_t cAttributes = 1;
+   constexpr size_t cAttributeCombinationsIndexes = 0;
+   constexpr size_t cCases = 1;
+
+   EbmAttribute attributes[std::max(std::size_t { 1 }, cAttributes)];
+   IntegerDataType combinationIndexes[std::max(std::size_t { 1 }, cAttributeCombinationsIndexes)];
+   IntegerDataType targets[std::max(std::size_t { 1 }, cCases)];
+   IntegerDataType data[std::max(std::size_t { 1 }, cCases * cAttributes)];
+   FractionalDataType predictionScores[std::max(std::size_t { 1 }, cCases * cVectorLength)];
+
+   attributes[0].attributeType = AttributeTypeOrdinal;
+   attributes[0].countStates = 2;
+   attributes[0].hasMissing = 0;
+
+   targets[0] = 0;
+   data[0] = 0;
+   predictionScores[0] = 0;
+   predictionScores[1] = 0;
+   predictionScores[2] = 0;
+
+   PEbmInteraction pEbmInteraction = InitializeInteractionClassification(cAttributes, attributes, countTargetStates, cCases, targets, data, predictionScores);
+
+   FractionalDataType metricReturn;
+   IntegerDataType result;
+   result = GetInteractionScore(pEbmInteraction, cAttributeCombinationsIndexes, combinationIndexes, &metricReturn);
+   CHECK(0 == result);
+   if(0 != result) {
+      return;
+   }
+   CHECK(0 == metricReturn);
+   FreeInteraction(pEbmInteraction);
+}
+
 
 void EBMCORE_CALLING_CONVENTION LogMessage(signed char traceLevel, const char * message) {
    printf("%d - %s\n", traceLevel, message);

--- a/src/core/TestCoreApi/TestCoreApi.cpp
+++ b/src/core/TestCoreApi/TestCoreApi.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 #include "ebmcore.h"
 

--- a/src/core/TestCoreApi/TestCoreApi.cpp
+++ b/src/core/TestCoreApi/TestCoreApi.cpp
@@ -81,9 +81,9 @@ inline bool IsApproxEqual(const double value, const double expected, const doubl
 
 constexpr size_t GetVectorLength(size_t cTargetStates) {
 #ifdef TREAT_BINARY_AS_MULTICLASS
-   return cTargetStates <= 1 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+   return cTargetStates <= 1 ? size_t { 1 } : static_cast<size_t>(cTargetStates);
 #else // TREAT_BINARY_AS_MULTICLASS
-   return cTargetStates <= 2 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+   return cTargetStates <= 2 ? size_t { 1 } : static_cast<size_t>(cTargetStates);
 #endif // TREAT_BINARY_AS_MULTICLASS
 }
 

--- a/src/core/TestCoreApi/TestCoreApi.cpp
+++ b/src/core/TestCoreApi/TestCoreApi.cpp
@@ -4,10 +4,81 @@
 
 #include "PrecompiledHeaderTestCoreApi.h"
 
-#include "ebmcore.h"
+// we roll our own test framework here since it's nice having no dependencies, and we just need a few simple tests for the C API.
+// If we ended up needing something more substantial, I'd consider using doctest ( https://github.com/onqtam/doctest ) because:
+//   1) It's a single include file, which is the simplest we could ask for.  Googletest is more heavyweight
+//   2) It's MIT licensed, so we could include the header in our project and still keep our license 100% MIT compatible without having two licenses, unlike Catch, or Catch2
+//   3) It's fast to compile.
+//   4) doctest is very close to having a JUnit output feature.  JUnit isn't really required, our python testing uses JUnit, so it would be nice to have the same format -> https://github.com/onqtam/doctest/blob/master/doc/markdown/roadmap.md   https://github.com/onqtam/doctest/issues/75
+//   5) If JUnit is desired in the meantime, there is a converter that will output JUnit -> https://github.com/ujiro99/doctest-junit-report
+//
+// In case we want to use doctest in the future, use the format of the following: TEST_CASE, CHECK & FAIL_CHECK (continues testing) / REQUIRE & FAIL (stops the current test, but we could just terminate), INFO (print to log file)
+// Don't implement this since it would be harder to do: SUBCASE
 
+#include <string>
 #include <stdio.h>
 #include <iostream>
+#include <vector>
+
+#include "ebmcore.h"
+
+class Test;
+typedef void (* TestFunction)(Test& myTest);
+
+class Test {
+public:
+   Test(TestFunction pTestFunction, std::string description) {
+      m_pTestFunction = pTestFunction;
+      m_description = description;
+      m_bPassed = true;
+   }
+
+   TestFunction m_pTestFunction;
+   std::string m_description;
+   bool m_bPassed;
+};
+
+std::vector<Test> g_tests;
+
+inline int RegisterTest(const Test& myTest) {
+   g_tests.push_back(myTest);
+   return 0;
+}
+
+#define COMBINE_TOKENS(t1, t2) t1##t2
+#define CONCATENATE(t1, t2) COMBINE_TOKENS(t1, t2)
+#define TEST_CASE(description) \
+   static void CONCATENATE(MY_TEST_FUNCTION_, __LINE__)(Test& myTest); \
+   static int CONCATENATE(STUPID, __LINE__) = RegisterTest(Test(CONCATENATE(MY_TEST_FUNCTION_, __LINE__), description)); \
+   static void CONCATENATE(MY_TEST_FUNCTION_, __LINE__)(Test& myTest)
+
+// for now we always terminate on error.  If it becomes a problem then make this more elegant
+#define CHECK(expression) \
+   do { \
+      bool bFailed = !(expression); \
+      if(bFailed) { \
+         std::cout << " FAILED on \"" #expression << "\""; \
+         myTest.m_bPassed = false; \
+      } \
+   } while((void)0, 0)
+
+// for now we always terminate on error.  If it becomes a problem then make this more elegant
+#define REQUIRE(expression) CHECK(expression)
+
+
+
+TEST_CASE("test 1") {
+   CHECK(true);
+}
+
+TEST_CASE("test 2") {
+   CHECK(true);
+   CHECK(true);
+}
+
+TEST_CASE("test 3") {
+   CHECK(true);
+}
 
 void EBMCORE_CALLING_CONVENTION LogMessage(signed char traceLevel, const char * message) {
    printf("%d - %s\n", traceLevel, message);
@@ -15,8 +86,20 @@ void EBMCORE_CALLING_CONVENTION LogMessage(signed char traceLevel, const char * 
 
 int main() {
    SetLogMessageFunction(&LogMessage);
-   SetTraceLevel(TraceLevelWarning);
+   SetTraceLevel(TraceLevelOff);
 
-   std::cout << "Hello World!\n";
-   return 0;
+   bool bPassed = true;
+   for(auto& myTest : g_tests) {
+      std::cout << "Starting test: " << myTest.m_description;
+      myTest.m_pTestFunction(myTest);
+      if(myTest.m_bPassed) {
+         std::cout << " PASSED" << std::endl;
+      } else {
+         bPassed = false;
+         std::cout << std::endl;
+      }
+   }
+
+   std::cout << "C API test " << (bPassed ? "PASSED" : "FAILED")  << std::endl;
+   return bPassed ? 0 : 1;
 }

--- a/src/core/TestCoreApi/TestCoreApi.vcxproj
+++ b/src/core/TestCoreApi/TestCoreApi.vcxproj
@@ -97,19 +97,21 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>PrecompiledHeaderTestCoreApi.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x64_debug.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <CustomBuildStep>
       <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x64_debug.dll</Outputs>
@@ -127,19 +129,21 @@ EXIT /B 0
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CONSOLE;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>PrecompiledHeaderTestCoreApi.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x86_debug.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <CustomBuildStep>
       <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x86_debug.dll</Outputs>
@@ -157,7 +161,7 @@ EXIT /B 0
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -166,6 +170,7 @@ EXIT /B 0
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>PrecompiledHeaderTestCoreApi.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -174,6 +179,7 @@ EXIT /B 0
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x86.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <CustomBuildStep>
       <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x86.dll</Outputs>
@@ -191,7 +197,7 @@ EXIT /B 0
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -200,6 +206,7 @@ EXIT /B 0
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>PrecompiledHeaderTestCoreApi.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -208,6 +215,7 @@ EXIT /B 0
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x64.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <CustomBuildStep>
       <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x64.dll</Outputs>

--- a/src/core/TestCoreApi/TestCoreApi.vcxproj
+++ b/src/core/TestCoreApi/TestCoreApi.vcxproj
@@ -111,7 +111,10 @@
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x64_debug.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
+    <CustomBuildStep>
+      <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x64_debug.dll</Outputs>
+      <Inputs>$(ProjectDir)..\..\..\staging\lib_ebmcore_win_x64_debug.dll</Inputs>
+      <Message>Copying ebmcore DLL to TestCoreApi</Message>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\staging" "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" lib_ebmcore_win_x64_debug.dll lib_ebmcore_win_x64_debug.pdb
 ECHO robocopy returned error code %ERRORLEVEL%
 IF %ERRORLEVEL% GEQ 2 (
@@ -119,11 +122,7 @@ IF %ERRORLEVEL% GEQ 2 (
 )
 EXIT /B 0
 </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
+    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -142,7 +141,10 @@ EXIT /B 0
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x86_debug.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
+    <CustomBuildStep>
+      <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x86_debug.dll</Outputs>
+      <Inputs>$(ProjectDir)..\..\..\staging\lib_ebmcore_win_x86_debug.dll</Inputs>
+      <Message>Copying ebmcore DLL to TestCoreApi</Message>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\staging" "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" lib_ebmcore_win_x86_debug.dll lib_ebmcore_win_x86_debug.pdb
 ECHO robocopy returned error code %ERRORLEVEL%
 IF %ERRORLEVEL% GEQ 2 (
@@ -150,11 +152,7 @@ IF %ERRORLEVEL% GEQ 2 (
 )
 EXIT /B 0
 </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
+    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -177,7 +175,10 @@ EXIT /B 0
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x86.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
+    <CustomBuildStep>
+      <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x86.dll</Outputs>
+      <Inputs>$(ProjectDir)..\..\..\staging\lib_ebmcore_win_x86.dll</Inputs>
+      <Message>Copying ebmcore DLL to TestCoreApi</Message>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\staging" "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" lib_ebmcore_win_x86.dll lib_ebmcore_win_x86.pdb
 ECHO robocopy returned error code %ERRORLEVEL%
 IF %ERRORLEVEL% GEQ 2 (
@@ -185,11 +186,7 @@ IF %ERRORLEVEL% GEQ 2 (
 )
 EXIT /B 0
 </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
+    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -212,7 +209,10 @@ EXIT /B 0
       <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\staging\</AdditionalLibraryDirectories>
       <AdditionalDependencies>lib_ebmcore_win_x64.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PostBuildEvent>
+    <CustomBuildStep>
+      <Outputs>$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)\lib_ebmcore_win_x64.dll</Outputs>
+      <Inputs>$(ProjectDir)..\..\..\staging\lib_ebmcore_win_x64.dll</Inputs>
+      <Message>Copying ebmcore DLL to TestCoreApi</Message>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\staging" "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" lib_ebmcore_win_x64.dll lib_ebmcore_win_x64.pdb
 ECHO robocopy returned error code %ERRORLEVEL%
 IF %ERRORLEVEL% GEQ 2 (
@@ -220,11 +220,7 @@ IF %ERRORLEVEL% GEQ 2 (
 )
 EXIT /B 0
 </Command>
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <Command>
-      </Command>
-    </PreBuildEvent>
+    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="PrecompiledHeaderTestCoreApi.cpp">

--- a/src/core/ebmcore/AttributeCombinationInternal.h
+++ b/src/core/ebmcore/AttributeCombinationInternal.h
@@ -26,8 +26,6 @@ public:
    AttributeCombinationEntry m_AttributeCombinationEntry[1];
 
    TML_INLINE static AttributeCombinationCore * Allocate(const size_t cAttributes, const size_t iAttributeCombination) {
-      EBM_ASSERT(0 < cAttributes);
-
       const size_t cBytes = sizeof(AttributeCombinationCore) - sizeof(AttributeCombinationEntry) + sizeof(AttributeCombinationEntry) * cAttributes;
       AttributeCombinationCore * const pAttributeCombination = static_cast<AttributeCombinationCore *>(malloc(cBytes));
       if(UNLIKELY(nullptr == pAttributeCombination)) {

--- a/src/core/ebmcore/AttributeCombinationInternal.h
+++ b/src/core/ebmcore/AttributeCombinationInternal.h
@@ -55,7 +55,7 @@ public:
 
       EBM_ASSERT(0 < cAttributeCombinations);
       AttributeCombinationCore ** const apAttributeCombinations = new (std::nothrow) AttributeCombinationCore * [cAttributeCombinations];
-      if (LIKELY(nullptr != apAttributeCombinations)) {
+      if(LIKELY(nullptr != apAttributeCombinations)) {
          // we need to set this to zero otherwise our destructor will attempt to free garbage memory pointers if we prematurely call the destructor
          EBM_ASSERT(!IsMultiplyError(sizeof(*apAttributeCombinations), cAttributeCombinations)); // if we were able to allocate this, then we should be able to calculate how much memory to zero
          memset(apAttributeCombinations, 0, sizeof(*apAttributeCombinations) * cAttributeCombinations);

--- a/src/core/ebmcore/AttributeCombinationInternal.h
+++ b/src/core/ebmcore/AttributeCombinationInternal.h
@@ -15,7 +15,7 @@ class AttributeCombinationCore final {
 public:
 
    struct AttributeCombinationEntry {
-      AttributeInternalCore * m_pAttribute;
+      const AttributeInternalCore * m_pAttribute;
    };
 
    size_t m_cItemsPerBitPackDataUnit;
@@ -25,16 +25,24 @@ public:
    unsigned int m_cLogExitMessages;
    AttributeCombinationEntry m_AttributeCombinationEntry[1];
 
+   TML_INLINE static size_t GetAttributeCombinationCountBytes(const size_t cAttributes) {
+      return sizeof(AttributeCombinationCore) - sizeof(AttributeCombinationCore::AttributeCombinationEntry) + sizeof(AttributeCombinationCore::AttributeCombinationEntry) * cAttributes;
+   }
+
+   TML_INLINE void Initialize(const size_t cAttributes, const size_t iAttributeCombination) {
+      m_cAttributes = cAttributes;
+      m_iInputData = iAttributeCombination;
+      m_cLogEnterMessages = 2;
+      m_cLogExitMessages = 2;
+   }
+
    TML_INLINE static AttributeCombinationCore * Allocate(const size_t cAttributes, const size_t iAttributeCombination) {
-      const size_t cBytes = sizeof(AttributeCombinationCore) - sizeof(AttributeCombinationEntry) + sizeof(AttributeCombinationEntry) * cAttributes;
+      const size_t cBytes = GetAttributeCombinationCountBytes(cAttributes);
       AttributeCombinationCore * const pAttributeCombination = static_cast<AttributeCombinationCore *>(malloc(cBytes));
       if(UNLIKELY(nullptr == pAttributeCombination)) {
          return nullptr;
       }
-      pAttributeCombination->m_cAttributes = cAttributes;
-      pAttributeCombination->m_iInputData = iAttributeCombination;
-      pAttributeCombination->m_cLogEnterMessages = 2;
-      pAttributeCombination->m_cLogExitMessages = 2;
+      pAttributeCombination->Initialize(cAttributes, iAttributeCombination);
       return pAttributeCombination;
    }
 
@@ -68,5 +76,22 @@ public:
    }
 };
 static_assert(std::is_pod<AttributeCombinationCore>::value, "We have an array at the end of this stucture, so we don't want anyone else derriving something and putting data there, and non-POD data is probably undefined as to what the space after gets filled with");
+
+// these need to be declared AFTER the class above since the size of AttributeCombinationCore isn't set until the class has been completely declared, and constexpr needs the size before constexpr
+constexpr size_t GetAttributeCombinationCountBytesConst(const size_t cAttributes) {
+   return sizeof(AttributeCombinationCore) - sizeof(AttributeCombinationCore::AttributeCombinationEntry) + sizeof(AttributeCombinationCore::AttributeCombinationEntry) * cAttributes;
+}
+constexpr size_t k_cBytesAttributeCombinationMax = GetAttributeCombinationCountBytesConst(k_cDimensionsMax);
+
+#ifndef NDEBUG
+class AttributeCombinationCheck final {
+public:
+   AttributeCombinationCheck() {
+      // we need two separate functions for determining the maximum size of AttributeCombinationCore, so let's check that they match at runtime
+      EBM_ASSERT(k_cBytesAttributeCombinationMax == AttributeCombinationCore::GetAttributeCombinationCountBytes(k_cDimensionsMax));
+   }
+};
+static AttributeCombinationCheck DEBUG_AttributeCombinationCheck; // yes, this gets duplicated for each include, but it's just for debug..
+#endif // NDEBUG
 
 #endif // ATTRIBUTE_COMBINATION_H

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -133,7 +133,6 @@ void BinDataSetTrainingZeroDimensions(BinnedBucket<IsRegression(countCompilerCla
 
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
-   const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
 
    const size_t cCases = pTrainingSet->m_pOriginDataSet->GetCountCases();
    EBM_ASSERT(0 < cCases);
@@ -158,13 +157,12 @@ void BinDataSetTrainingZeroDimensions(BinnedBucket<IsRegression(countCompilerCla
       pBinnedBucketEntry->cCasesInBucket += cOccurences;
       const FractionalDataType cFloatOccurences = static_cast<FractionalDataType>(cOccurences);
 
+#ifndef NDEBUG
 #ifdef TREAT_BINARY_AS_MULTICLASS
       constexpr bool bTreatBinaryAsMulticlass = true;
 #else // TREAT_BINARY_AS_MULTICLASS
       constexpr bool bTreatBinaryAsMulticlass = false;
 #endif // TREAT_BINARY_AS_MULTICLASS
-
-#ifndef NDEBUG
       FractionalDataType residualTotalDebug = 0;
 #endif // NDEBUG
       size_t iVector = 0;

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -168,7 +168,7 @@ void BinDataSetTrainingZeroDimensions(BinnedBucket<IsRegression(countCompilerCla
       size_t iVector = 0;
       do {
          const FractionalDataType residualError = *pResidualError;
-         EBM_ASSERT(!IsClassification(countCompilerClassificationTargetStates) || 2 == cTargetStates && !bTreatBinaryAsMulticlass || iVector != k_iZeroResidual || 0 == residualError);
+         EBM_ASSERT(!IsClassification(countCompilerClassificationTargetStates) || 2 == cTargetStates && !bTreatBinaryAsMulticlass || static_cast<ptrdiff_t>(iVector) != k_iZeroResidual || 0 == residualError);
 #ifndef NDEBUG
          residualTotalDebug += residualError;
 #endif // NDEBUG
@@ -260,7 +260,7 @@ void BinDataSetTraining(BinnedBucket<IsRegression(countCompilerClassificationTar
 #endif // NDEBUG
          do {
             const FractionalDataType residualError = *pResidualError;
-            EBM_ASSERT(!IsClassification(countCompilerClassificationTargetStates) || 2 == cTargetStates && !bTreatBinaryAsMulticlass || iVector != k_iZeroResidual || 0 == residualError);
+            EBM_ASSERT(!IsClassification(countCompilerClassificationTargetStates) || 2 == cTargetStates && !bTreatBinaryAsMulticlass || static_cast<ptrdiff_t>(iVector) != k_iZeroResidual || 0 == residualError);
 #ifndef NDEBUG
             residualTotalDebug += residualError;
 #endif // NDEBUG

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -39,19 +39,19 @@ template<bool bRegression>
 class BinnedBucket;
 
 template<bool bRegression>
-constexpr TML_INLINE bool GetBinnedBucketSizeOverflow(const size_t cVectorLength) {
+TML_INLINE bool GetBinnedBucketSizeOverflow(const size_t cVectorLength) {
    return IsMultiplyError(sizeof(PredictionStatistics<bRegression>), cVectorLength) ? true : IsAddError(sizeof(BinnedBucket<bRegression>) - sizeof(PredictionStatistics<bRegression>), sizeof(PredictionStatistics<bRegression>) * cVectorLength) ? true : false;
 }
 template<bool bRegression>
-constexpr TML_INLINE size_t GetBinnedBucketSize(const size_t cVectorLength) {
+TML_INLINE size_t GetBinnedBucketSize(const size_t cVectorLength) {
    return sizeof(BinnedBucket<bRegression>) - sizeof(PredictionStatistics<bRegression>) + sizeof(PredictionStatistics<bRegression>) * cVectorLength;
 }
 template<bool bRegression>
-constexpr TML_INLINE BinnedBucket<bRegression> * GetBinnedBucketByIndex(const size_t cBytesPerBinnedBucket, BinnedBucket<bRegression> * const aBinnedBuckets, const ptrdiff_t index) {
+TML_INLINE BinnedBucket<bRegression> * GetBinnedBucketByIndex(const size_t cBytesPerBinnedBucket, BinnedBucket<bRegression> * const aBinnedBuckets, const ptrdiff_t index) {
    return reinterpret_cast<BinnedBucket<bRegression> *>(reinterpret_cast<char *>(aBinnedBuckets) + index * static_cast<ptrdiff_t>(cBytesPerBinnedBucket));
 }
 template<bool bRegression>
-constexpr TML_INLINE const BinnedBucket<bRegression> * GetBinnedBucketByIndex(const size_t cBytesPerBinnedBucket, const BinnedBucket<bRegression> * const aBinnedBuckets, const ptrdiff_t index) {
+TML_INLINE const BinnedBucket<bRegression> * GetBinnedBucketByIndex(const size_t cBytesPerBinnedBucket, const BinnedBucket<bRegression> * const aBinnedBuckets, const ptrdiff_t index) {
    return reinterpret_cast<const BinnedBucket<bRegression> *>(reinterpret_cast<const char *>(aBinnedBuckets) + index * static_cast<ptrdiff_t>(cBytesPerBinnedBucket));
 }
 

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -127,6 +127,71 @@ public:
 static_assert(std::is_pod<BinnedBucket<false>>::value, "BinnedBucket will be more efficient as a POD as we make potentially large arrays of them!");
 static_assert(std::is_pod<BinnedBucket<true>>::value, "BinnedBucket will be more efficient as a POD as we make potentially large arrays of them!");
 
+template<ptrdiff_t countCompilerClassificationTargetStates>
+void BinDataSetTrainingZeroDimensions(BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pBinnedBucketEntry, const SamplingMethod * const pTrainingSet, const size_t cTargetStates) {
+   LOG(TraceLevelVerbose, "Entered BinDataSetTrainingZeroDimensions");
+
+   const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
+   EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
+   const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
+
+   const size_t cCases = pTrainingSet->m_pOriginDataSet->GetCountCases();
+   EBM_ASSERT(0 < cCases);
+
+   const SamplingWithReplacement * const pSamplingWithReplacement = static_cast<const SamplingWithReplacement *>(pTrainingSet);
+   const size_t * pCountOccurrences = pSamplingWithReplacement->m_aCountOccurrences;
+   const FractionalDataType * pResidualError = pSamplingWithReplacement->m_pOriginDataSet->GetResidualPointer();
+   // this shouldn't overflow since we're accessing existing memory
+   const FractionalDataType * const pResidualErrorEnd = pResidualError + cVectorLength * cCases;
+
+   PredictionStatistics<IsRegression(countCompilerClassificationTargetStates)> * const pPredictionStatistics = &pBinnedBucketEntry->aPredictionStatistics[0];
+   while(pResidualErrorEnd != pResidualError) {
+      // this loop gets about twice as slow if you add a single unpredictable branching if statement based on count, even if you still access all the memory in complete sequential order, so we'll probably want to use non-branching instructions for any solution like conditional selection or multiplication
+      // this loop gets about 3 times slower if you use a bad pseudo random number generator like rand(), although it might be better if you inlined rand().
+      // this loop gets about 10 times slower if you use a proper pseudo random number generator like std::default_random_engine
+      // taking all the above together, it seems unlikley we'll use a method of separating sets via single pass randomized set splitting.  Even if count is stored in memory if shouldn't increase the time spent fetching it by 2 times, unless our bottleneck when threading is overwhelmingly memory pressure related, and even then we could store the count for a single bit aleviating the memory pressure greatly, if we use the right sampling method 
+
+      // TODO : try using a sampling method with non-repeating cases, and put the count into a bit.  Then unwind that loop either at the byte level (8 times) or the uint64_t level.  This can be done without branching and doesn't require random number generators
+
+      const size_t cOccurences = *pCountOccurrences;
+      ++pCountOccurrences;
+      pBinnedBucketEntry->cCasesInBucket += cOccurences;
+      const FractionalDataType cFloatOccurences = static_cast<FractionalDataType>(cOccurences);
+
+#ifdef TREAT_BINARY_AS_MULTICLASS
+      constexpr bool bTreatBinaryAsMulticlass = true;
+#else // TREAT_BINARY_AS_MULTICLASS
+      constexpr bool bTreatBinaryAsMulticlass = false;
+#endif // TREAT_BINARY_AS_MULTICLASS
+
+#ifndef NDEBUG
+      FractionalDataType residualTotalDebug = 0;
+#endif // NDEBUG
+      size_t iVector = 0;
+      do {
+         const FractionalDataType residualError = *pResidualError;
+         EBM_ASSERT(!IsClassification(countCompilerClassificationTargetStates) || 2 == cTargetStates && !bTreatBinaryAsMulticlass || iVector != k_iZeroResidual || 0 == residualError);
+#ifndef NDEBUG
+         residualTotalDebug += residualError;
+#endif // NDEBUG
+         pPredictionStatistics[iVector].sumResidualError += cFloatOccurences * residualError;
+         if(IsClassification(countCompilerClassificationTargetStates)) {
+            // TODO : this code gets executed for each SamplingWithReplacement set.  I could probably execute it once and then all the SamplingWithReplacement sets would have this value, but I would need to store the computation in a new memory place, and it might make more sense to calculate this values in the CPU rather than put more pressure on memory.  I think controlling this should be done in a MACRO and we should use a class to hold the residualError and this computation from that value and then comment out the computation if not necssary and access it through an accessor so that we can make the change entirely via macro
+            const FractionalDataType absResidualError = std::abs(residualError); // abs will return the same type that it is given, either float or double
+            pPredictionStatistics[iVector].SetSumDenominator(pPredictionStatistics[iVector].GetSumDenominator() + cFloatOccurences * (absResidualError * (1 - absResidualError)));
+         }
+         ++pResidualError;
+         ++iVector;
+         // if we use this specific format where (iVector < cVectorLength) then the compiler collapses alway the loop for small cVectorLength values
+         // if we make this (iVector != cVectorLength) then the loop is not collapsed
+         // the compiler seems to not mind if we make this a for loop or do loop in terms of collapsing away the loop
+      } while(iVector < cVectorLength);
+
+      EBM_ASSERT(!IsClassification(countCompilerClassificationTargetStates) || 2 == cTargetStates && !bTreatBinaryAsMulticlass || 0 <= k_iZeroResidual || -0.00000000001 < residualTotalDebug && residualTotalDebug < 0.00000000001);
+   }
+   LOG(TraceLevelVerbose, "Exited BinDataSetTrainingZeroDimensions");
+}
+
 // TODO : remove cCompilerDimensions since we don't need it anymore, and replace it with a more useful number like the number of cItemsPerBitPackDataUnit
 template<ptrdiff_t countCompilerClassificationTargetStates, size_t cCompilerDimensions>
 void BinDataSetTraining(BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const aBinnedBuckets, const AttributeCombinationCore * const pAttributeCombination, const SamplingMethod * const pTrainingSet, const size_t cTargetStates
@@ -303,6 +368,8 @@ void BinDataSetInteraction(BinnedBucket<IsRegression(countCompilerClassification
    const FractionalDataType * pResidualError = pDataSet->GetResidualPointer();
    const FractionalDataType * const pResidualErrorEnd = pResidualError + cVectorLength * pDataSet->GetCountCases();
 
+   size_t cAttributes = pAttributeCombination->m_cAttributes;
+   EBM_ASSERT(1 <= cAttributes); // for interactions, we just return 0 for interactions with zero attributes
    for(size_t iCase = 0; pResidualErrorEnd != pResidualError; ++iCase) {
       // this loop gets about twice as slow if you add a single unpredictable branching if statement based on count, even if you still access all the memory in complete sequential order, so we'll probably want to use non-branching instructions for any solution like conditional selection or multiplication
       // this loop gets about 3 times slower if you use a bad pseudo random number generator like rand(), although it might be better if you inlined rand().
@@ -315,7 +382,8 @@ void BinDataSetInteraction(BinnedBucket<IsRegression(countCompilerClassification
 
       size_t cBuckets = 1;
       size_t iBucket = 0;
-      for(size_t iDimension = 0; iDimension < pAttributeCombination->m_cAttributes; ++iDimension) {
+      size_t iDimension = 0;
+      do {
          const AttributeInternalCore * const pInputAttribute = pAttributeCombination->m_AttributeCombinationEntry[iDimension].m_pAttribute;
          const size_t cStates = pInputAttribute->m_cStates;
          const StorageDataTypeCore * pInputData = pDataSet->GetDataPointer(pInputAttribute);
@@ -326,8 +394,9 @@ void BinDataSetInteraction(BinnedBucket<IsRegression(countCompilerClassification
          EBM_ASSERT(iState < cStates);
          iBucket += cBuckets * iState;
          cBuckets *= cStates;
-      }
-
+         ++iDimension;
+      } while(iDimension < cAttributes);
+ 
       BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * pBinnedBucketEntry = GetBinnedBucketByIndex<IsRegression(countCompilerClassificationTargetStates)>(cBytesPerBinnedBucket, aBinnedBuckets, iBucket);
       ASSERT_BINNED_BUCKET_OK(cBytesPerBinnedBucket, pBinnedBucketEntry, aBinnedBucketsEndDebug);
       pBinnedBucketEntry->cCasesInBucket += 1;

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -263,6 +263,10 @@ public:
       }
    }
 };
+
+WARNING_PUSH
+WARNING_DISABLE_UNREFERENCED_PARAMETER
+
 template<ptrdiff_t countCompilerClassificationTargetStates>
 class RecursiveBinDataSetTraining<countCompilerClassificationTargetStates, k_cDimensionsMax> {
    // C++ does not allow partial function specialization, so we need to use these cumbersome inline static class functions to do partial function specialization
@@ -280,6 +284,8 @@ public:
       );
    }
 };
+
+WARNING_POP
 
 // TODO: make the number of dimensions (pAttributeCombination->m_cAttributes) a template parameter so that we don't have to have the inner loop that is very bad for performance.  Since the data will be stored contiguously and have the same length in the future, we can just loop based on the number of dimensions, so we might as well have a couple of different values
 template<ptrdiff_t countCompilerClassificationTargetStates>

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -328,9 +328,6 @@ public:
    }
 };
 
-WARNING_PUSH
-WARNING_DISABLE_UNREFERENCED_PARAMETER
-
 template<ptrdiff_t countCompilerClassificationTargetStates>
 class RecursiveBinDataSetTraining<countCompilerClassificationTargetStates, k_cDimensionsMax> {
    // C++ does not allow partial function specialization, so we need to use these cumbersome inline static class functions to do partial function specialization
@@ -349,8 +346,6 @@ public:
       );
    }
 };
-
-WARNING_POP
 
 // TODO: make the number of dimensions (pAttributeCombination->m_cAttributes) a template parameter so that we don't have to have the inner loop that is very bad for performance.  Since the data will be stored contiguously and have the same length in the future, we can just loop based on the number of dimensions, so we might as well have a couple of different values
 template<ptrdiff_t countCompilerClassificationTargetStates>

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -250,13 +250,12 @@ void BinDataSetTraining(BinnedBucket<IsRegression(countCompilerClassificationTar
          PredictionStatistics<IsRegression(countCompilerClassificationTargetStates)> * pPredictionStatistics = &pBinnedBucketEntry->aPredictionStatistics[0];
          size_t iVector = 0;
 
+#ifndef NDEBUG
 #ifdef TREAT_BINARY_AS_MULTICLASS
          constexpr bool bTreatBinaryAsMulticlass = true;
 #else // TREAT_BINARY_AS_MULTICLASS
          constexpr bool bTreatBinaryAsMulticlass = false;
 #endif // TREAT_BINARY_AS_MULTICLASS
-
-#ifndef NDEBUG
          FractionalDataType residualTotalDebug = 0;
 #endif // NDEBUG
          do {

--- a/src/core/ebmcore/BinnedBucket.h
+++ b/src/core/ebmcore/BinnedBucket.h
@@ -111,6 +111,7 @@ public:
 
    template<ptrdiff_t countCompilerClassificationTargetStates>
    TML_INLINE void AssertZero(const size_t cTargetStates) {
+      UNUSED(cTargetStates);
       static_assert(IsRegression(countCompilerClassificationTargetStates) == bRegression, "regression types must match");
 #ifndef NDEBUG
       const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
@@ -339,6 +340,7 @@ public:
       , const unsigned char * const aBinnedBucketsEndDebug
 #endif // NDEBUG
    ) {
+      UNUSED(cRuntimeDimensions);
       EBM_ASSERT(k_cDimensionsMax == cRuntimeDimensions);
       BinDataSetTraining<countCompilerClassificationTargetStates, k_cDimensionsMax>(aBinnedBuckets, pAttributeCombination, pTrainingSet, cTargetStates
 #ifndef NDEBUG

--- a/src/core/ebmcore/CachedThreadResources.h
+++ b/src/core/ebmcore/CachedThreadResources.h
@@ -25,7 +25,7 @@ public:
 };
 
 template<bool bRegression>
-class PredictionStatistics;
+struct PredictionStatistics;
 
 template<bool bRegression>
 class CachedTrainingThreadResources {

--- a/src/core/ebmcore/DataSetByAttribute.cpp
+++ b/src/core/ebmcore/DataSetByAttribute.cpp
@@ -24,14 +24,14 @@ TML_INLINE static const FractionalDataType * ConstructResidualErrors(const bool 
    const size_t cVectorLength = GetVectorLengthFlatCore(cTargetStates);
    EBM_ASSERT(1 <= cVectorLength);
 
-   if (IsMultiplyError(cCases, cVectorLength)) {
+   if(IsMultiplyError(cCases, cVectorLength)) {
       LOG(TraceLevelWarning, "WARNING DataSetInternalCore::ConstructResidualErrors IsMultiplyError(cCases, cVectorLength)");
       return nullptr;
    }
 
    const size_t cElements = cCases * cVectorLength;
 
-   if (IsMultiplyError(sizeof(FractionalDataType), cElements)) {
+   if(IsMultiplyError(sizeof(FractionalDataType), cElements)) {
       LOG(TraceLevelWarning, "WARNING DataSetInternalCore::ConstructResidualErrors IsMultiplyError(sizeof(FractionalDataType), cElements)");
       return nullptr;
    }
@@ -60,13 +60,13 @@ TML_INLINE static const StorageDataTypeCore * const * ConstructInputData(const s
    }
    const size_t cSubBytesData = sizeof(StorageDataTypeCore) * cCases;
 
-   if (IsMultiplyError(sizeof(void *), cAttributes)) {
+   if(IsMultiplyError(sizeof(void *), cAttributes)) {
       LOG(TraceLevelWarning, "WARNING DataSetInternalCore::ConstructInputData IsMultiplyError(sizeof(void *), cAttributes)");
       return nullptr;
    }
    const size_t cBytesMemoryArray = sizeof(void *) * cAttributes;
    StorageDataTypeCore ** const aaInputDataTo = static_cast<StorageDataTypeCore * *>(malloc(cBytesMemoryArray));
-   if (nullptr == aaInputDataTo) {
+   if(nullptr == aaInputDataTo) {
       LOG(TraceLevelWarning, "WARNING DataSetInternalCore::ConstructInputData nullptr == aaInputDataTo");
       return nullptr;
    }
@@ -76,7 +76,7 @@ TML_INLINE static const StorageDataTypeCore * const * ConstructInputData(const s
    const AttributeInternalCore * const pAttributeEnd = aAttributes + cAttributes;
    do {
       StorageDataTypeCore * pInputDataTo = static_cast<StorageDataTypeCore *>(malloc(cSubBytesData));
-      if (nullptr == pInputDataTo) {
+      if(nullptr == pInputDataTo) {
          LOG(TraceLevelWarning, "WARNING DataSetInternalCore::ConstructInputData nullptr == pInputDataTo");
          goto free_all;
       }
@@ -84,7 +84,7 @@ TML_INLINE static const StorageDataTypeCore * const * ConstructInputData(const s
       ++paInputDataTo;
 
       // TODO : eliminate the counts here and use pointers
-      for (size_t iCase = 0; iCase < cCases; ++iCase) {
+      for(size_t iCase = 0; iCase < cCases; ++iCase) {
          // TODO: eliminate this extra internal index lookup (very bad!).  Since the attributes will be in-order, we can probably just use a single pointer to the input data and just keep incrementing it over all the attributes
          const IntegerDataType data = aInputDataFrom[pAttribute->m_iAttributeData * cCases + iCase];
          EBM_ASSERT(0 <= data);
@@ -95,13 +95,13 @@ TML_INLINE static const StorageDataTypeCore * const * ConstructInputData(const s
       }
 
       ++pAttribute;
-   } while (pAttributeEnd != pAttribute);
+   } while(pAttributeEnd != pAttribute);
 
    LOG(TraceLevelInfo, "Exited DataSetInternalCore::ConstructInputData");
    return aaInputDataTo;
 
 free_all:
-   while (aaInputDataTo != paInputDataTo) {
+   while(aaInputDataTo != paInputDataTo) {
       --paInputDataTo;
       free(*paInputDataTo);
    }
@@ -123,7 +123,7 @@ DataSetInternalCore::~DataSetInternalCore() {
    LOG(TraceLevelInfo, "Entered ~DataSetInternalCore");
 
    free(const_cast<FractionalDataType *>(m_aResidualErrors));
-   if (nullptr != m_aaInputData) {
+   if(nullptr != m_aaInputData) {
       EBM_ASSERT(1 <= m_cAttributes);
       const StorageDataTypeCore * const * paInputData = m_aaInputData;
       const StorageDataTypeCore * const * const paInputDataEnd = m_aaInputData + m_cAttributes;
@@ -131,7 +131,7 @@ DataSetInternalCore::~DataSetInternalCore() {
          EBM_ASSERT(nullptr != *paInputData);
          free(const_cast<StorageDataTypeCore *>(*paInputData));
          ++paInputData;
-      } while (paInputDataEnd != paInputData);
+      } while(paInputDataEnd != paInputData);
       free(const_cast<StorageDataTypeCore * *>(m_aaInputData));
    }
 

--- a/src/core/ebmcore/DataSetByAttribute.cpp
+++ b/src/core/ebmcore/DataSetByAttribute.cpp
@@ -124,7 +124,7 @@ DataSetInternalCore::~DataSetInternalCore() {
 
    free(const_cast<FractionalDataType *>(m_aResidualErrors));
    if (nullptr != m_aaInputData) {
-      EBM_ASSERT(0 < m_cAttributes);
+      EBM_ASSERT(1 <= m_cAttributes);
       const StorageDataTypeCore * const * paInputData = m_aaInputData;
       const StorageDataTypeCore * const * const paInputDataEnd = m_aaInputData + m_cAttributes;
       do {

--- a/src/core/ebmcore/DataSetByAttribute.cpp
+++ b/src/core/ebmcore/DataSetByAttribute.cpp
@@ -39,7 +39,15 @@ TML_INLINE static const FractionalDataType * ConstructResidualErrors(const bool 
    const size_t cBytes = sizeof(FractionalDataType) * cElements;
    FractionalDataType * aResidualErrors = static_cast<FractionalDataType *>(malloc(cBytes));
 
-   InitializeResidualsFlat(bRegression, cCases, aTargetData, aPredictionScores, aResidualErrors, cTargetStates);
+   if(bRegression) {
+      InitializeResiduals<k_Regression>(cCases, aTargetData, aPredictionScores, aResidualErrors, 0);
+   } else {
+      if(2 == cTargetStates) {
+         InitializeResiduals<2>(cCases, aTargetData, aPredictionScores, aResidualErrors, 2);
+      } else {
+         InitializeResiduals<k_DynamicClassification>(cCases, aTargetData, aPredictionScores, aResidualErrors, cTargetStates);
+      }
+   }
 
    LOG(TraceLevelInfo, "Exited DataSetInternalCore::ConstructResidualErrors");
    return aResidualErrors;

--- a/src/core/ebmcore/DataSetByAttributeCombination.cpp
+++ b/src/core/ebmcore/DataSetByAttributeCombination.cpp
@@ -72,7 +72,8 @@ TML_INLINE static FractionalDataType * ConstructPredictionScores(const size_t cC
       memset(aPredictionScoresTo, 0, cBytes);
    } else {
       memcpy(aPredictionScoresTo, aPredictionScoresFrom, cBytes);
-      if(0 <= k_iZeroClassificationLogitAtInitialize) {
+      constexpr bool bZeroingLogits = 0 <= k_iZeroClassificationLogitAtInitialize;
+      if(bZeroingLogits) {
          // TODO : integrate this subtraction into the copy instead of doing it afterwards
          FractionalDataType * pScore = aPredictionScoresTo;
          const FractionalDataType * const pScoreExteriorEnd = pScore + cVectorLength * cCases;

--- a/src/core/ebmcore/DataSetByAttributeCombination.cpp
+++ b/src/core/ebmcore/DataSetByAttributeCombination.cpp
@@ -16,7 +16,7 @@
 #include "AttributeCombinationInternal.h"
 #include "DataSetByAttributeCombination.h"
 
-#define INVALID_POINTER (reinterpret_cast<void *>(~static_cast<size_t>(0)))
+#define INVALID_POINTER (reinterpret_cast<void *>(~ size_t { 0 }))
 
 TML_INLINE static FractionalDataType * ConstructResidualErrors(const size_t cCases, const size_t cVectorLength) {
    LOG(TraceLevelInfo, "Entered DataSetAttributeCombination::ConstructResidualErrors");

--- a/src/core/ebmcore/DataSetByAttributeCombination.cpp
+++ b/src/core/ebmcore/DataSetByAttributeCombination.cpp
@@ -104,6 +104,10 @@ TML_INLINE static const StorageDataTypeCore * ConstructTargetData(const size_t c
    }
    const size_t cTargetArrayBytes = sizeof(StorageDataTypeCore) * cCases;
    StorageDataTypeCore * const aTargetData = static_cast<StorageDataTypeCore *>(malloc(cTargetArrayBytes));
+   if(nullptr == aTargetData) {
+      LOG(TraceLevelWarning, "WARNING nullptr == aTargetData");
+      return nullptr;
+   }
 
    const IntegerDataType * pTargetFrom = aTargets;
    const IntegerDataType * const pTargetFromEnd = aTargets + cCases;

--- a/src/core/ebmcore/DataSetByAttributeCombination.cpp
+++ b/src/core/ebmcore/DataSetByAttributeCombination.cpp
@@ -152,94 +152,98 @@ TML_INLINE static const StorageDataTypeCore * const * ConstructInputData(const s
    do {
       const AttributeCombinationCore * const pAttributeCombination = *ppAttributeCombination;
       EBM_ASSERT(nullptr != pAttributeCombination);
-      const size_t cItemsPerBitPackDataUnit = pAttributeCombination->m_cItemsPerBitPackDataUnit;
-      EBM_ASSERT(cItemsPerBitPackDataUnit <= CountBitsRequiredPositiveMax<StorageDataTypeCore>()); // for a 32/64 bit storage item, we can't have more than 32/64 bit packed items stored
-      const size_t cBitsPerItemMax = GetCountBits(cItemsPerBitPackDataUnit);
-      EBM_ASSERT(cBitsPerItemMax <= CountBitsRequiredPositiveMax<StorageDataTypeCore>()); // if we have 1 item, it can't be larger than the number of bits of storage
+      const size_t cAttributes = pAttributeCombination->m_cAttributes;
+      if(0 == cAttributes) {
+         *paInputDataTo = nullptr; // free will skip over these later
+      } else {
+         const size_t cItemsPerBitPackDataUnit = pAttributeCombination->m_cItemsPerBitPackDataUnit;
+         EBM_ASSERT(cItemsPerBitPackDataUnit <= CountBitsRequiredPositiveMax<StorageDataTypeCore>()); // for a 32/64 bit storage item, we can't have more than 32/64 bit packed items stored
+         const size_t cBitsPerItemMax = GetCountBits(cItemsPerBitPackDataUnit);
+         EBM_ASSERT(cBitsPerItemMax <= CountBitsRequiredPositiveMax<StorageDataTypeCore>()); // if we have 1 item, it can't be larger than the number of bits of storage
 
-      EBM_ASSERT(0 < cCases);
-      const size_t cDataUnits = (cCases - 1) / cItemsPerBitPackDataUnit + 1; // this can't overflow or underflow
+         EBM_ASSERT(0 < cCases);
+         const size_t cDataUnits = (cCases - 1) / cItemsPerBitPackDataUnit + 1; // this can't overflow or underflow
 
-      if(IsMultiplyError(sizeof(StorageDataTypeCore), cDataUnits)) {
-         LOG(TraceLevelWarning, "WARNING DataSetAttributeCombination::ConstructInputData IsMultiplyError(sizeof(StorageDataTypeCore), cDataUnits)");
-         goto free_all;
-      }
-      const size_t cBytesData = sizeof(StorageDataTypeCore) * cDataUnits;
-      StorageDataTypeCore * pInputDataTo = static_cast<StorageDataTypeCore *>(malloc(cBytesData));
-      if(nullptr == pInputDataTo) {
-         LOG(TraceLevelWarning, "WARNING DataSetAttributeCombination::ConstructInputData nullptr == pInputDataTo");
-         goto free_all;
-      }
-      *paInputDataTo = pInputDataTo;
-      ++paInputDataTo;
+         if(IsMultiplyError(sizeof(StorageDataTypeCore), cDataUnits)) {
+            LOG(TraceLevelWarning, "WARNING DataSetAttributeCombination::ConstructInputData IsMultiplyError(sizeof(StorageDataTypeCore), cDataUnits)");
+            goto free_all;
+         }
+         const size_t cBytesData = sizeof(StorageDataTypeCore) * cDataUnits;
+         StorageDataTypeCore * pInputDataTo = static_cast<StorageDataTypeCore *>(malloc(cBytesData));
+         if(nullptr == pInputDataTo) {
+            LOG(TraceLevelWarning, "WARNING DataSetAttributeCombination::ConstructInputData nullptr == pInputDataTo");
+            goto free_all;
+         }
+         *paInputDataTo = pInputDataTo;
+         ++paInputDataTo;
 
-      // stop on the last item in our array AND then do one special last loop with less or equal iterations to the normal loop
-      const StorageDataTypeCore * const pInputDataToLast = reinterpret_cast<const StorageDataTypeCore *>(reinterpret_cast<const char *>(pInputDataTo) + cBytesData) - 1;
-      EBM_ASSERT(pInputDataTo <= pInputDataToLast); // we have 1 item or more, and therefore the last one can't be before the first item
+         // stop on the last item in our array AND then do one special last loop with less or equal iterations to the normal loop
+         const StorageDataTypeCore * const pInputDataToLast = reinterpret_cast<const StorageDataTypeCore *>(reinterpret_cast<const char *>(pInputDataTo) + cBytesData) - 1;
+         EBM_ASSERT(pInputDataTo <= pInputDataToLast); // we have 1 item or more, and therefore the last one can't be before the first item
 
-      const AttributeCombinationCore::AttributeCombinationEntry * pAttributeCombinationEntry = &pAttributeCombination->m_AttributeCombinationEntry[0];
-      InputDataPointerAndCountStates dimensionInfo[k_cDimensionsMax];
-      InputDataPointerAndCountStates * pDimensionInfo = &dimensionInfo[0];
-      EBM_ASSERT(0 < pAttributeCombination->m_cAttributes);
-      const InputDataPointerAndCountStates * const pDimensionInfoEnd = &dimensionInfo[pAttributeCombination->m_cAttributes];
-      do {
-         const AttributeInternalCore * const pAttribute = pAttributeCombinationEntry->m_pAttribute;
-         pDimensionInfo->m_pInputData = &aInputDataFrom[pAttribute->m_iAttributeData * cCases];
-         pDimensionInfo->m_cStates = pAttribute->m_cStates;
-         ++pAttributeCombinationEntry;
-         ++pDimensionInfo;
-      } while(pDimensionInfoEnd != pDimensionInfo);
-
-      // THIS IS NOT A CONSTANT FOR A REASON.. WE CHANGE IT ON OUR LAST ITERATION
-      // if we ever template this function on cItemsPerBitPackDataUnit, then we'd want
-      // to make this a constant so that the compiler could reason about it an eliminate loops
-      // as it is, it isn't a constant, so the compiler would not be able to figure out that most
-      // of the time it is a constant
-      size_t shiftEnd = cBitsPerItemMax * cItemsPerBitPackDataUnit;
-      while(pInputDataTo < pInputDataToLast) /* do the last iteration AFTER we re-enter this loop through the goto label! */ {
-      one_last_loop:;
-         EBM_ASSERT(shiftEnd <= CountBitsRequiredPositiveMax<StorageDataTypeCore>());
-
-         size_t bits = 0;
-         size_t shift = 0;
+         const AttributeCombinationCore::AttributeCombinationEntry * pAttributeCombinationEntry = &pAttributeCombination->m_AttributeCombinationEntry[0];
+         InputDataPointerAndCountStates dimensionInfo[k_cDimensionsMax];
+         InputDataPointerAndCountStates * pDimensionInfo = &dimensionInfo[0];
+         EBM_ASSERT(0 < cAttributes);
+         const InputDataPointerAndCountStates * const pDimensionInfoEnd = &dimensionInfo[cAttributes];
          do {
-            size_t tensorMultiple = 1;
-            size_t tensorIndex = 0;
-            pDimensionInfo = &dimensionInfo[0];
+            const AttributeInternalCore * const pAttribute = pAttributeCombinationEntry->m_pAttribute;
+            pDimensionInfo->m_pInputData = &aInputDataFrom[pAttribute->m_iAttributeData * cCases];
+            pDimensionInfo->m_cStates = pAttribute->m_cStates;
+            ++pAttributeCombinationEntry;
+            ++pDimensionInfo;
+         } while(pDimensionInfoEnd != pDimensionInfo);
+
+         // THIS IS NOT A CONSTANT FOR A REASON.. WE CHANGE IT ON OUR LAST ITERATION
+         // if we ever template this function on cItemsPerBitPackDataUnit, then we'd want
+         // to make this a constant so that the compiler could reason about it an eliminate loops
+         // as it is, it isn't a constant, so the compiler would not be able to figure out that most
+         // of the time it is a constant
+         size_t shiftEnd = cBitsPerItemMax * cItemsPerBitPackDataUnit;
+         while(pInputDataTo < pInputDataToLast) /* do the last iteration AFTER we re-enter this loop through the goto label! */ {
+         one_last_loop:;
+            EBM_ASSERT(shiftEnd <= CountBitsRequiredPositiveMax<StorageDataTypeCore>());
+
+            size_t bits = 0;
+            size_t shift = 0;
             do {
-               const IntegerDataType * pInputData = pDimensionInfo->m_pInputData;
-               const IntegerDataType inputData = *pInputData;
-               pDimensionInfo->m_pInputData = pInputData + 1;
+               size_t tensorMultiple = 1;
+               size_t tensorIndex = 0;
+               pDimensionInfo = &dimensionInfo[0];
+               do {
+                  const IntegerDataType * pInputData = pDimensionInfo->m_pInputData;
+                  const IntegerDataType inputData = *pInputData;
+                  pDimensionInfo->m_pInputData = pInputData + 1;
 
-               EBM_ASSERT(0 <= inputData);
-               EBM_ASSERT((IsNumberConvertable<size_t, IntegerDataType>(inputData))); // data must be lower than cTargetStates and cTargetStates fits into a size_t which we checked earlier
-               EBM_ASSERT(static_cast<size_t>(inputData) < pDimensionInfo->m_cStates);
-               EBM_ASSERT(!IsMultiplyError(tensorMultiple, pDimensionInfo->m_cStates)); // we check for overflows during AttributeCombination construction, but let's check here again
+                  EBM_ASSERT(0 <= inputData);
+                  EBM_ASSERT((IsNumberConvertable<size_t, IntegerDataType>(inputData))); // data must be lower than cTargetStates and cTargetStates fits into a size_t which we checked earlier
+                  EBM_ASSERT(static_cast<size_t>(inputData) < pDimensionInfo->m_cStates);
+                  EBM_ASSERT(!IsMultiplyError(tensorMultiple, pDimensionInfo->m_cStates)); // we check for overflows during AttributeCombination construction, but let's check here again
 
-               tensorIndex += tensorMultiple * static_cast<size_t>(inputData); // this can't overflow if the multiplication below doesn't overflow, and we checked for that above
-               tensorMultiple *= pDimensionInfo->m_cStates;
+                  tensorIndex += tensorMultiple * static_cast<size_t>(inputData); // this can't overflow if the multiplication below doesn't overflow, and we checked for that above
+                  tensorMultiple *= pDimensionInfo->m_cStates;
 
-               ++pDimensionInfo;
-            } while(pDimensionInfoEnd != pDimensionInfo);
-            // put our first item in the least significant bits.  We do this so that later when
-            // unpacking the indexes, we can just AND our mask with the bitfield to get the index and in subsequent loops
-            // we can just shift down.  This eliminates one extra shift that we'd otherwise need to make if the first
-            // item was in the MSB
-            EBM_ASSERT(shift < CountBitsRequiredPositiveMax<StorageDataTypeCore>());
-            bits |= tensorIndex << shift;
-            shift += cBitsPerItemMax;
-         } while(shiftEnd != shift);
-         EBM_ASSERT((IsNumberConvertable<StorageDataTypeCore, size_t>(bits)));
-         *pInputDataTo = static_cast<StorageDataTypeCore>(bits);
-         ++pInputDataTo;
+                  ++pDimensionInfo;
+               } while(pDimensionInfoEnd != pDimensionInfo);
+               // put our first item in the least significant bits.  We do this so that later when
+               // unpacking the indexes, we can just AND our mask with the bitfield to get the index and in subsequent loops
+               // we can just shift down.  This eliminates one extra shift that we'd otherwise need to make if the first
+               // item was in the MSB
+               EBM_ASSERT(shift < CountBitsRequiredPositiveMax<StorageDataTypeCore>());
+               bits |= tensorIndex << shift;
+               shift += cBitsPerItemMax;
+            } while(shiftEnd != shift);
+            EBM_ASSERT((IsNumberConvertable<StorageDataTypeCore, size_t>(bits)));
+            *pInputDataTo = static_cast<StorageDataTypeCore>(bits);
+            ++pInputDataTo;
+         }
+
+         if(pInputDataTo == pInputDataToLast) {
+            // if this is the first time we've exited the loop, then re-enter it to do our last loop, but reduce the number of times we do the inner loop
+            shiftEnd = cBitsPerItemMax * ((cCases - 1) % cItemsPerBitPackDataUnit + 1);
+            goto one_last_loop;
+         }
       }
-
-      if(pInputDataTo == pInputDataToLast) {
-         // if this is the first time we've exited the loop, then re-enter it to do our last loop, but reduce the number of times we do the inner loop
-         shiftEnd = cBitsPerItemMax * ((cCases - 1) % cItemsPerBitPackDataUnit + 1);
-         goto one_last_loop;
-      }
-
       ++ppAttributeCombination;
    } while(ppAttributeCombinationEnd != ppAttributeCombination);
 
@@ -284,7 +288,6 @@ DataSetAttributeCombination::~DataSetAttributeCombination() {
       const StorageDataTypeCore * const * paInputData = m_aaInputData;
       const StorageDataTypeCore * const * const paInputDataEnd = m_aaInputData + m_cAttributeCombinations;
       do {
-         EBM_ASSERT(nullptr != *paInputData);
          free(const_cast<StorageDataTypeCore *>(*paInputData));
          ++paInputData;
       } while(paInputDataEnd != paInputData);

--- a/src/core/ebmcore/DllMainCore.cpp
+++ b/src/core/ebmcore/DllMainCore.cpp
@@ -8,6 +8,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#pragma warning(suppress : 4100)
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved) {
    switch(ul_reason_for_call) {
    case DLL_PROCESS_ATTACH:
@@ -18,4 +19,3 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
    }
    return TRUE;
 }
-

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -12,6 +12,7 @@
 
 #define WARNING_PUSH _Pragma("clang diagnostic push")
 #define WARNING_POP _Pragma("clang diagnostic pop")
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
@@ -19,6 +20,7 @@
 
 #define WARNING_PUSH _Pragma("GCC diagnostic push")
 #define WARNING_POP _Pragma("GCC diagnostic pop")
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
@@ -26,6 +28,7 @@
 
 #define WARNING_PUSH __pragma(warning(push))
 #define WARNING_POP __pragma(warning(pop))
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER __pragma(warning(disable: 4100))
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH __pragma(warning(disable: 4018))
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO __pragma(warning(disable: 4723))
 

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -15,7 +15,7 @@
 
 #define WARNING_PUSH _Pragma("clang diagnostic push")
 #define WARNING_POP _Pragma("clang diagnostic pop")
-#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("clang diagnostic ignored \"-Wmaybe-uninitialized\"")
+#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("clang diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -18,6 +18,7 @@
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("clang diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
+#define WARNING_DISABLE_NON_LITERAL_PRINTF_STRING _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
 
 #elif defined(__GNUC__) // compiler type
 
@@ -26,6 +27,7 @@
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
+#define WARNING_DISABLE_NON_LITERAL_PRINTF_STRING
 
 #elif defined(_MSC_VER) // compiler type
 
@@ -34,6 +36,7 @@
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE __pragma(warning(disable: 4701))
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH __pragma(warning(disable: 4018))
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO __pragma(warning(disable: 4723))
+#define WARNING_DISABLE_NON_LITERAL_PRINTF_STRING
 
 #else  // compiler type
 #error compiler not recognized
@@ -55,6 +58,14 @@
 #endif // __has_builtin(__builtin_unpredictable)
 
 #define TML_INLINE inline __attribute__((always_inline))
+
+// TODO : use EBM_RESTRICT_FUNCTION_RETURN EBM_RESTRICT_PARAM_VARIABLE and EBM_NOALIAS.  This helps performance by telling the compiler that pointers are not aliased
+// EBM_RESTRICT_FUNCTION_RETURN tells the compiler that a pointer returned from a function in not aliased in any other part of the program (the memory wasn't reached previously)
+#define EBM_RESTRICT_FUNCTION_RETURN __declspec(restrict)
+// EBM_RESTRICT_PARAM_VARIABLE tells the compiler that a pointer passed into a function doesn't refer to memory passed in via annohter pointer
+#define EBM_RESTRICT_PARAM_VARIABLE __restrict
+// EBM_NOALIAS tells the compiler that a function does not modify global state and only modified data DIRECTLY pointed to via it's parameters (first level indirection)
+#define EBM_NOALIAS __declspec(noalias)
 
 #elif defined(_MSC_VER) // compiler type
 

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -7,12 +7,14 @@
 
 #include <inttypes.h>
 #include <stddef.h> // size_t, ptrdiff_t
+#include <limits> // numeric_limits
 
 #if defined(__clang__) // compiler type
 
 #define WARNING_PUSH _Pragma("clang diagnostic push")
 #define WARNING_POP _Pragma("clang diagnostic pop")
 #define WARNING_DISABLE_UNREFERENCED_PARAMETER
+#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
@@ -21,6 +23,7 @@
 #define WARNING_PUSH _Pragma("GCC diagnostic push")
 #define WARNING_POP _Pragma("GCC diagnostic pop")
 #define WARNING_DISABLE_UNREFERENCED_PARAMETER
+#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
@@ -29,6 +32,7 @@
 #define WARNING_PUSH __pragma(warning(push))
 #define WARNING_POP __pragma(warning(pop))
 #define WARNING_DISABLE_UNREFERENCED_PARAMETER __pragma(warning(disable: 4100))
+#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE __pragma(warning(disable: 4701))
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH __pragma(warning(disable: 4018))
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO __pragma(warning(disable: 4723))
 
@@ -229,6 +233,8 @@ constexpr TML_INLINE size_t GetNextCountItemsBitPacked(const size_t cItemsBitPac
    return k_cBitsForStorageType / ((k_cBitsForStorageType / cItemsBitPackedPrev) + 1);
 }
 
+WARNING_PUSH
+WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 // TODO : also check for places where to convert a size_t into a ptrdiff_t and check for overflow there throughout our code
 // TODO : there are many places that could be overflowing multiplication.  We need to look for places where this might happen
 constexpr TML_INLINE bool IsMultiplyError(size_t num1, size_t num2) {
@@ -241,6 +247,7 @@ constexpr TML_INLINE bool IsMultiplyError(size_t num1, size_t num2) {
    // it will never overflow if num1 is zero
    return 0 != num1 && ((std::numeric_limits<size_t>::max() - num1 + 1) / num1 < num2);
 }
+WARNING_POP
 
 constexpr TML_INLINE bool IsAddError(size_t num1, size_t num2) {
    // overflow for unsigned values is defined behavior in C++ and it causes a wrap arround

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -9,11 +9,14 @@
 #include <stddef.h> // size_t, ptrdiff_t
 #include <limits> // numeric_limits
 
+#define UNUSED(x) (void)(x)
+
 #if defined(__clang__) // compiler type
 
 #define WARNING_PUSH _Pragma("clang diagnostic push")
 #define WARNING_POP _Pragma("clang diagnostic pop")
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("clang diagnostic ignored \"-Wunused-parameter\"")
+//#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("clang diagnostic ignored \"-Wunused-parameter\"")
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("clang diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("clang diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
@@ -22,7 +25,8 @@
 
 #define WARNING_PUSH _Pragma("GCC diagnostic push")
 #define WARNING_POP _Pragma("GCC diagnostic pop")
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
+//#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
@@ -31,7 +35,8 @@
 
 #define WARNING_PUSH __pragma(warning(push))
 #define WARNING_POP __pragma(warning(pop))
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER __pragma(warning(disable: 4100))
+//#define WARNING_DISABLE_UNREFERENCED_PARAMETER __pragma(warning(disable: 4100))
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE __pragma(warning(disable: 4701))
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH __pragma(warning(disable: 4018))
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO __pragma(warning(disable: 4723))

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -15,7 +15,7 @@
 #define WARNING_POP _Pragma("clang diagnostic pop")
 #define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("clang diagnostic ignored \"-Wunused-parameter\"")
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("clang diagnostic ignored \"-Wmaybe-uninitialized\"")
-#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
+#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("clang diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
 #elif defined(__GNUC__) // compiler type
@@ -24,7 +24,7 @@
 #define WARNING_POP _Pragma("GCC diagnostic pop")
 #define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
+#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
 #elif defined(_MSC_VER) // compiler type
@@ -255,7 +255,7 @@ constexpr TML_INLINE bool IsAddError(size_t num1, size_t num2) {
 }
 
 // TODO : keep this constant, but make it global and compile out the costs... we want to document that it's possible and how, but we have tested it and found it's worse
-static constexpr int k_iZeroResidual = -1;
-static constexpr int k_iZeroClassificationLogitAtInitialize = -1;
+static constexpr ptrdiff_t k_iZeroResidual = -1;
+static constexpr ptrdiff_t k_iZeroClassificationLogitAtInitialize = -1;
 
 #endif // TRANSPARENT_ML_CORE_INTERNAL_H

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -198,9 +198,9 @@ constexpr TML_INLINE size_t GetVectorLengthFlatCore(size_t cTargetStates) {
 #define GET_ATTRIBUTE_COMBINATION_DIMENSIONS(MACRO_countCompilerDimensions, MACRO_countRuntimeDimensions) ((MACRO_countCompilerDimensions) <= 0 ? static_cast<size_t>(MACRO_countRuntimeDimensions) : static_cast<size_t>(MACRO_countCompilerDimensions))
 
 template<typename T>
-constexpr size_t CountBitsRequiredCore(T cBitsMax) {
+constexpr size_t CountBitsRequiredCore(T maxValue) {
    // this is a bit inefficient when called in the runtime, but we don't call it anywhere that's important performance wise.
-   return 0 == cBitsMax ? 0 : 1 + CountBitsRequiredCore<T>(cBitsMax / 2);
+   return 0 == maxValue ? 0 : 1 + CountBitsRequiredCore<T>(maxValue / 2);
 }
 template<typename T>
 constexpr size_t CountBitsRequiredPositiveMax() {

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -13,8 +13,8 @@
 
 #define WARNING_PUSH _Pragma("clang diagnostic push")
 #define WARNING_POP _Pragma("clang diagnostic pop")
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER
-#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("clang diagnostic ignored \"-Wunused-parameter\"")
+#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("clang diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
@@ -23,7 +23,7 @@
 #define WARNING_PUSH _Pragma("GCC diagnostic push")
 #define WARNING_POP _Pragma("GCC diagnostic pop")
 #define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
-#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
+#define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -22,7 +22,7 @@
 
 #define WARNING_PUSH _Pragma("GCC diagnostic push")
 #define WARNING_POP _Pragma("GCC diagnostic pop")
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER
+#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
@@ -55,7 +55,7 @@
 #define UNPREDICTABLE(b) (b)
 #endif // __has_builtin(__builtin_unpredictable)
 
-#define TML_INLINE inline
+#define TML_INLINE inline __attribute__((always_inline))
 
 #elif defined(_MSC_VER) // compiler type
 

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -163,17 +163,17 @@ constexpr TML_INLINE bool IsBinaryClassification(ptrdiff_t cCompilerClassificati
 constexpr TML_INLINE size_t GetVectorLengthFlatCore(ptrdiff_t cTargetStates) {
    // this will work for anything except if countCompilerClassificationTargetStates is set to DYNAMIC_CLASSIFICATION which means we should have passed in the dynamic value since DYNAMIC_CLASSIFICATION is a constant that doesn't tell us anything about the real value
 #ifdef TREAT_BINARY_AS_MULTICLASS
-   return cTargetStates <= 1 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+   return cTargetStates <= 1 ? size_t { 1 } : static_cast<size_t>(cTargetStates);
 #else // TREAT_BINARY_AS_MULTICLASS
-   return cTargetStates <= 2 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+   return cTargetStates <= 2 ? size_t { 1 } : static_cast<size_t>(cTargetStates);
 #endif // TREAT_BINARY_AS_MULTICLASS
 }
 constexpr TML_INLINE size_t GetVectorLengthFlatCore(size_t cTargetStates) {
    // this will work for anything except if countCompilerClassificationTargetStates is set to DYNAMIC_CLASSIFICATION which means we should have passed in the dynamic value since DYNAMIC_CLASSIFICATION is a constant that doesn't tell us anything about the real value
 #ifdef TREAT_BINARY_AS_MULTICLASS
-   return cTargetStates <= 1 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+   return cTargetStates <= 1 ? size_t { 1 } : static_cast<size_t>(cTargetStates);
 #else // TREAT_BINARY_AS_MULTICLASS
-   return cTargetStates <= 2 ? static_cast<size_t>(1) : static_cast<size_t>(cTargetStates);
+   return cTargetStates <= 2 ? size_t { 1 } : static_cast<size_t>(cTargetStates);
 #endif // TREAT_BINARY_AS_MULTICLASS
 }
 

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -15,8 +15,6 @@
 
 #define WARNING_PUSH _Pragma("clang diagnostic push")
 #define WARNING_POP _Pragma("clang diagnostic pop")
-//#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("clang diagnostic ignored \"-Wunused-parameter\"")
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("clang diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("clang diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
@@ -25,8 +23,6 @@
 
 #define WARNING_PUSH _Pragma("GCC diagnostic push")
 #define WARNING_POP _Pragma("GCC diagnostic pop")
-//#define WARNING_DISABLE_UNREFERENCED_PARAMETER _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
@@ -35,8 +31,6 @@
 
 #define WARNING_PUSH __pragma(warning(push))
 #define WARNING_POP __pragma(warning(pop))
-//#define WARNING_DISABLE_UNREFERENCED_PARAMETER __pragma(warning(disable: 4100))
-#define WARNING_DISABLE_UNREFERENCED_PARAMETER
 #define WARNING_DISABLE_UNINITIALIZED_LOCAL_VARIABLE __pragma(warning(disable: 4701))
 #define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH __pragma(warning(disable: 4018))
 #define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO __pragma(warning(disable: 4723))

--- a/src/core/ebmcore/EbmInternal.h
+++ b/src/core/ebmcore/EbmInternal.h
@@ -8,6 +8,31 @@
 #include <inttypes.h>
 #include <stddef.h> // size_t, ptrdiff_t
 
+#if defined(__clang__) // compiler type
+
+#define WARNING_PUSH _Pragma("clang diagnostic push")
+#define WARNING_POP _Pragma("clang diagnostic pop")
+#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
+#define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
+
+#elif defined(__GNUC__) // compiler type
+
+#define WARNING_PUSH _Pragma("GCC diagnostic push")
+#define WARNING_POP _Pragma("GCC diagnostic pop")
+#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
+#define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
+
+#elif defined(_MSC_VER) // compiler type
+
+#define WARNING_PUSH __pragma(warning(push))
+#define WARNING_POP __pragma(warning(pop))
+#define WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH __pragma(warning(disable: 4018))
+#define WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO __pragma(warning(disable: 4723))
+
+#else  // compiler type
+#error compiler not recognized
+#endif // compiler type
+
 #if defined(__clang__) || defined(__GNUC__) // compiler
 #ifndef __has_builtin
 #define __has_builtin(x) 0 // __has_builtin is supported in newer compilers.  On older compilers diable anything we would check with it
@@ -24,23 +49,21 @@
 #endif // __has_builtin(__builtin_unpredictable)
 
 #define TML_INLINE inline
-#elif defined(_MSC_VER) /* compiler type */
+
+#elif defined(_MSC_VER) // compiler type
+
 #define LIKELY(b) (b)
 #define UNLIKELY(b) (b)
 #define PREDICTABLE(b) (b)
 #define UNPREDICTABLE(b) (b)
 #define TML_INLINE __forceinline
-#else // compiler
-#error compiler not recognized
-#endif // compiler
 
-#if defined(__clang__) || defined(__GNUC__) // compiler
-#elif defined(_MSC_VER) /* compiler type */
-#pragma warning(push)
-#pragma warning(disable: 4018) // signed/unsigned mismatch
-#else // compiler
+#else // compiler type
 #error compiler not recognized
-#endif // compiler
+#endif // compiler type
+
+WARNING_PUSH
+WARNING_DISABLE_SIGNED_UNSIGNED_MISMATCH
 
 template<typename TTo, typename TFrom>
 constexpr TML_INLINE bool IsNumberConvertable(TFrom number) {
@@ -90,12 +113,8 @@ constexpr TML_INLINE bool IsNumberConvertable(TFrom number) {
    //   }
    //}
 }
-#if defined(__clang__) || defined(__GNUC__) // compiler
-#elif defined(_MSC_VER) /* compiler type */
-#pragma warning(pop)
-#else // compiler
-#error compiler not recognized
-#endif // compiler
+
+WARNING_POP
 
 enum AttributeTypeCore { OrdinalCore = 0, NominalCore = 1};
 

--- a/src/core/ebmcore/EbmStatistics.h
+++ b/src/core/ebmcore/EbmStatistics.h
@@ -12,105 +12,109 @@
 #include "EbmInternal.h" // TML_INLINE
 #include "Logging.h" // EBM_ASSERT & LOG
 
-TML_INLINE FractionalDataType ComputeNodeSplittingScore(const FractionalDataType sumResidualError, const size_t cCases) {
-   // TODO: after we eliminate bin compression, we should be checking to see if cCases is zero before divding by it.. Instead of doing that outside this function, we can move all instances of checking for zero into this function
-   EBM_ASSERT(0 < cCases); // we purge bins that have case counts of zero, so cCases should never be zero
-   return sumResidualError / cCases * sumResidualError;
-}
-
-WARNING_PUSH
-WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
-
-TML_INLINE FractionalDataType ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(const FractionalDataType sumResidualError, const FractionalDataType sumDenominator) {
-   if(LIKELY(static_cast<FractionalDataType>(0) != sumDenominator)) {
-      // this is a very predictable branch, so we'd prefer this to be an actual branch rather than an unpredictable one
-      return sumResidualError / sumDenominator;
-   } else {
-      return static_cast<FractionalDataType>(0);
+class EbmStatistics final {
+   TML_INLINE EbmStatistics() {
+      // DON'T allow anyone to make this static class
    }
-}
+public:
+   TML_INLINE static FractionalDataType ComputeNodeSplittingScore(const FractionalDataType sumResidualError, const size_t cCases) {
+      // TODO: after we eliminate bin compression, we should be checking to see if cCases is zero before divding by it.. Instead of doing that outside this function, we can move all instances of checking for zero into this function
+      EBM_ASSERT(0 < cCases); // we purge bins that have case counts of zero, so cCases should never be zero
+      return sumResidualError / cCases * sumResidualError;
+   }
 
-WARNING_POP
+   WARNING_PUSH
+   WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
+   TML_INLINE static FractionalDataType ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(const FractionalDataType sumResidualError, const FractionalDataType sumDenominator) {
+      if(LIKELY(static_cast<FractionalDataType>(0) != sumDenominator)) {
+         // this is a very predictable branch, so we'd prefer this to be an actual branch rather than an unpredictable one
+         return sumResidualError / sumDenominator;
+      } else {
+         return static_cast<FractionalDataType>(0);
+      }
+   }
+   WARNING_POP
 
-TML_INLINE FractionalDataType ComputeSmallChangeInRegressionPredictionForOneSegment(const FractionalDataType sumResidualError, const size_t cCases) {
-   // TODO: check again if we can ever have a zero here
-   // TODO: after we eliminate bin compression, we should be checking to see if cCases is zero before divding by it.. Instead of doing that outside this function, we can move all instances of checking for zero into this function
-   EBM_ASSERT(0 != cCases);
-   return sumResidualError / cCases;
-}
+   TML_INLINE static FractionalDataType ComputeSmallChangeInRegressionPredictionForOneSegment(const FractionalDataType sumResidualError, const size_t cCases) {
+      // TODO: check again if we can ever have a zero here
+      // TODO: after we eliminate bin compression, we should be checking to see if cCases is zero before divding by it.. Instead of doing that outside this function, we can move all instances of checking for zero into this function
+      EBM_ASSERT(0 != cCases);
+      return sumResidualError / cCases;
+   }
 
-TML_INLINE FractionalDataType ComputeRegressionResidualError(const FractionalDataType predictionScore, const FractionalDataType actualValue) {
-   const FractionalDataType result = actualValue - predictionScore;
-   return result;
-}
+   TML_INLINE static FractionalDataType ComputeRegressionResidualError(const FractionalDataType predictionScore, const FractionalDataType actualValue) {
+      const FractionalDataType result = actualValue - predictionScore;
+      return result;
+   }
 
-TML_INLINE FractionalDataType ComputeRegressionResidualError(const FractionalDataType value) {
-   // this function is here to document where we're calculating regression, like ComputeClassificationResidualErrorBinaryclass below.  It doesn't do anything, but it serves as an indication that the calculation would be placed here if we changed it in the future
-   return value;
-}
+   TML_INLINE static FractionalDataType ComputeRegressionResidualError(const FractionalDataType value) {
+      // this function is here to document where we're calculating regression, like ComputeClassificationResidualErrorBinaryclass below.  It doesn't do anything, but it serves as an indication that the calculation would be placed here if we changed it in the future
+      return value;
+   }
 
-TML_INLINE FractionalDataType ComputeClassificationResidualErrorBinaryclass(const FractionalDataType trainingLogOddsPrediction, const StorageDataTypeCore binnedActualValue) {
-   EBM_ASSERT(0 == binnedActualValue || 1 == binnedActualValue);
+   TML_INLINE static FractionalDataType ComputeClassificationResidualErrorBinaryclass(const FractionalDataType trainingLogOddsPrediction, const StorageDataTypeCore binnedActualValue) {
+      EBM_ASSERT(0 == binnedActualValue || 1 == binnedActualValue);
 
-   // this function outputs 0 if we perfectly predict the target with 100% certainty.  To do so, trainingLogOddsPrediction would need to be either infinity or -infinity
-   // this function outputs 1 if actual value was 1 but we incorrectly predicted with 100% certainty that it was 0 by having trainingLogOddsPrediction be -infinity
-   // this function outputs -1 if actual value was 0 but we incorrectly predicted with 100% certainty that it was 1 by having trainingLogOddsPrediction be infinity
-   //
-   // this function outputs 0.5 if actual value was 1 but we were 50%/50% by having trainingLogOddsPrediction be 0
-   // this function outputs -0.5 if actual value was 0 but we were 50%/50% by having trainingLogOddsPrediction be 0
+      // this function outputs 0 if we perfectly predict the target with 100% certainty.  To do so, trainingLogOddsPrediction would need to be either infinity or -infinity
+      // this function outputs 1 if actual value was 1 but we incorrectly predicted with 100% certainty that it was 0 by having trainingLogOddsPrediction be -infinity
+      // this function outputs -1 if actual value was 0 but we incorrectly predicted with 100% certainty that it was 1 by having trainingLogOddsPrediction be infinity
+      //
+      // this function outputs 0.5 if actual value was 1 but we were 50%/50% by having trainingLogOddsPrediction be 0
+      // this function outputs -0.5 if actual value was 0 but we were 50%/50% by having trainingLogOddsPrediction be 0
 
-   // TODO : this assembly is using branches instead of conditional execution.  Try finding something that will work without any branching, like multiplication, even if it's slower without branch misses
+      // TODO : this assembly is using branches instead of conditional execution.  Try finding something that will work without any branching, like multiplication, even if it's slower without branch misses
 
-   // TODO: instead of negating trainingLogOddsPrediction and then conditionally assigning it, can we multiply it with the result of the first conditional -1 vs 1
-   return (UNPREDICTABLE(0 == binnedActualValue) ? -1 : 1) / (1 + std::exp(UNPREDICTABLE(0 == binnedActualValue) ? -trainingLogOddsPrediction : trainingLogOddsPrediction)); // exp will return the same type that it is given, either float or double
-}
+      // TODO: instead of negating trainingLogOddsPrediction and then conditionally assigning it, can we multiply it with the result of the first conditional -1 vs 1
+      return (UNPREDICTABLE(0 == binnedActualValue) ? -1 : 1) / (1 + std::exp(UNPREDICTABLE(0 == binnedActualValue) ? -trainingLogOddsPrediction : trainingLogOddsPrediction)); // exp will return the same type that it is given, either float or double
+   }
 
-// if trainingLogOddsPrediction is zero (so, 50%/50% odds), then we can call this function
-TML_INLINE FractionalDataType ComputeClassificationResidualErrorBinaryclass(const StorageDataTypeCore binnedActualValue) {
-   EBM_ASSERT(0 == binnedActualValue || 1 == binnedActualValue);
-   const FractionalDataType result = UNPREDICTABLE(0 == binnedActualValue) ? -0.5 : 0.5;
-   EBM_ASSERT(ComputeClassificationResidualErrorBinaryclass(0, binnedActualValue) == result);
-   return result;
-}
+   // if trainingLogOddsPrediction is zero (so, 50%/50% odds), then we can call this function
+   TML_INLINE static FractionalDataType ComputeClassificationResidualErrorBinaryclass(const StorageDataTypeCore binnedActualValue) {
+      EBM_ASSERT(0 == binnedActualValue || 1 == binnedActualValue);
+      const FractionalDataType result = UNPREDICTABLE(0 == binnedActualValue) ? -0.5 : 0.5;
+      EBM_ASSERT(ComputeClassificationResidualErrorBinaryclass(0, binnedActualValue) == result);
+      return result;
+   }
 
-TML_INLINE FractionalDataType ComputeClassificationResidualErrorMulticlass(const FractionalDataType sumExp, const FractionalDataType trainingLogWeight, const StorageDataTypeCore binnedActualValue, const StorageDataTypeCore iVector) {
-   // TODO: is it better to use the non-branching conditional below, or is it better to assign all the items the negation case and then AFTERWARDS adding one to the single case that is equal to iVector 
-   const FractionalDataType yi = UNPREDICTABLE(iVector == binnedActualValue) ? static_cast<FractionalDataType>(1) : static_cast<FractionalDataType>(0);
-   const FractionalDataType ret = yi - std::exp(trainingLogWeight) / sumExp;
-   return ret;
-}
+   TML_INLINE static FractionalDataType ComputeClassificationResidualErrorMulticlass(const FractionalDataType sumExp, const FractionalDataType trainingLogWeight, const StorageDataTypeCore binnedActualValue, const StorageDataTypeCore iVector) {
+      // TODO: is it better to use the non-branching conditional below, or is it better to assign all the items the negation case and then AFTERWARDS adding one to the single case that is equal to iVector 
+      const FractionalDataType yi = UNPREDICTABLE(iVector == binnedActualValue) ? static_cast<FractionalDataType>(1) : static_cast<FractionalDataType>(0);
+      const FractionalDataType ret = yi - std::exp(trainingLogWeight) / sumExp;
+      return ret;
+   }
 
-// if trainingLogWeight is zero, we can call this simpler function
-TML_INLINE FractionalDataType ComputeClassificationResidualErrorMulticlass(const bool isMatch, const FractionalDataType sumExp) {
-   const FractionalDataType yi = UNPREDICTABLE(isMatch) ? static_cast<FractionalDataType>(1) : static_cast<FractionalDataType>(0);
-   const FractionalDataType ret = yi - static_cast<FractionalDataType>(1) / sumExp;
+   // if trainingLogWeight is zero, we can call this simpler function
+   TML_INLINE static FractionalDataType ComputeClassificationResidualErrorMulticlass(const bool isMatch, const FractionalDataType sumExp) {
+      const FractionalDataType yi = UNPREDICTABLE(isMatch) ? static_cast<FractionalDataType>(1) : static_cast<FractionalDataType>(0);
+      const FractionalDataType ret = yi - static_cast<FractionalDataType>(1) / sumExp;
 
-   EBM_ASSERT(!isMatch || ComputeClassificationResidualErrorMulticlass(sumExp, 0, 1, 1) == ret);
-   EBM_ASSERT(isMatch || ComputeClassificationResidualErrorMulticlass(sumExp, 0, 1, 2) == ret);
+      EBM_ASSERT(!isMatch || ComputeClassificationResidualErrorMulticlass(sumExp, 0, 1, 1) == ret);
+      EBM_ASSERT(isMatch || ComputeClassificationResidualErrorMulticlass(sumExp, 0, 1, 2) == ret);
 
-   return ret;
-}
+      return ret;
+   }
 
-// if trainingLogWeight is zero, we can call this simpler function
-TML_INLINE FractionalDataType ComputeClassificationResidualErrorMulticlass(const StorageDataTypeCore binnedActualValue, const StorageDataTypeCore iVector, const FractionalDataType matchValue, const FractionalDataType nonMatchValue) {
-   // TODO: is it better to use the non-branching conditional below, or is it better to assign all the items the negation case and then AFTERWARDS adding one to the single case that is equal to iVector 
-   const FractionalDataType ret = UNPREDICTABLE(iVector == binnedActualValue) ? matchValue : nonMatchValue;
-   return ret;
-}
+   // if trainingLogWeight is zero, we can call this simpler function
+   TML_INLINE static FractionalDataType ComputeClassificationResidualErrorMulticlass(const StorageDataTypeCore binnedActualValue, const StorageDataTypeCore iVector, const FractionalDataType matchValue, const FractionalDataType nonMatchValue) {
+      // TODO: is it better to use the non-branching conditional below, or is it better to assign all the items the negation case and then AFTERWARDS adding one to the single case that is equal to iVector 
+      const FractionalDataType ret = UNPREDICTABLE(iVector == binnedActualValue) ? matchValue : nonMatchValue;
+      return ret;
+   }
 
-TML_INLINE FractionalDataType ComputeClassificationSingleCaseLogLossBinaryclass(const FractionalDataType validationLogOddsPrediction, const StorageDataTypeCore binnedActualValue) {
-   EBM_ASSERT(0 == binnedActualValue || 1 == binnedActualValue);
+   TML_INLINE static FractionalDataType ComputeClassificationSingleCaseLogLossBinaryclass(const FractionalDataType validationLogOddsPrediction, const StorageDataTypeCore binnedActualValue) {
+      EBM_ASSERT(0 == binnedActualValue || 1 == binnedActualValue);
 
-   // TODO: also try log1p and I guess (exp1p?) for accuracy and performance
-   // TODO: the calls to log and exp have loops and conditional statements.  Suposedly the assembly FYL2X is slower than the C++ log/exp functions.  Look into this more.  We might end up sorting our input data by the target to avoid this if we can't find a non-branching solution because branch prediction will be important here
-   // https://stackoverflow.com/questions/45785705/logarithm-in-c-and-assembly
+      // TODO: also try log1p and I guess (exp1p?) for accuracy and performance
+      // TODO: the calls to log and exp have loops and conditional statements.  Suposedly the assembly FYL2X is slower than the C++ log/exp functions.  Look into this more.  We might end up sorting our input data by the target to avoid this if we can't find a non-branching solution because branch prediction will be important here
+      // https://stackoverflow.com/questions/45785705/logarithm-in-c-and-assembly
 
-   return std::log(1 + std::exp(UNPREDICTABLE(0 == binnedActualValue) ? validationLogOddsPrediction : -validationLogOddsPrediction)); // log & exp will return the same type that it is given, either float or double
-}
+      return std::log(1 + std::exp(UNPREDICTABLE(0 == binnedActualValue) ? validationLogOddsPrediction : -validationLogOddsPrediction)); // log & exp will return the same type that it is given, either float or double
+   }
 
-TML_INLINE FractionalDataType ComputeClassificationSingleCaseLogLossMulticlass(const FractionalDataType sumExp, const FractionalDataType * const aValidationLogWeight, const StorageDataTypeCore binnedActualValue) {
-   // TODO: is there any way to avoid doing the negation below, like changing sumExp or what we store in memory?
-   return -std::log(std::exp(aValidationLogWeight[binnedActualValue]) / sumExp);
-}
+   TML_INLINE static FractionalDataType ComputeClassificationSingleCaseLogLossMulticlass(const FractionalDataType sumExp, const FractionalDataType * const aValidationLogWeight, const StorageDataTypeCore binnedActualValue) {
+      // TODO: is there any way to avoid doing the negation below, like changing sumExp or what we store in memory?
+      return -std::log(std::exp(aValidationLogWeight[binnedActualValue]) / sumExp);
+   }
+};
 
 #endif // STATISTICS_H

--- a/src/core/ebmcore/EbmStatistics.h
+++ b/src/core/ebmcore/EbmStatistics.h
@@ -18,13 +18,8 @@ TML_INLINE FractionalDataType ComputeNodeSplittingScore(const FractionalDataType
    return sumResidualError / cCases * sumResidualError;
 }
 
-#if defined(__clang__) || defined(__GNUC__) // compiler
-#elif defined(_MSC_VER) /* compiler type */
-#pragma warning(push)
-#pragma warning(disable: 4723) // potential divide by 0
-#else // compiler
-#error compiler not recognized
-#endif // compiler
+WARNING_PUSH
+WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
 
 TML_INLINE FractionalDataType ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(const FractionalDataType sumResidualError, const FractionalDataType sumDenominator) {
    if(LIKELY(static_cast<FractionalDataType>(0) != sumDenominator)) {
@@ -34,12 +29,8 @@ TML_INLINE FractionalDataType ComputeSmallChangeInClassificationLogOddPrediction
       return static_cast<FractionalDataType>(0);
    }
 }
-#if defined(__clang__) || defined(__GNUC__) // compiler
-#elif defined(_MSC_VER) /* compiler type */
-#pragma warning(pop)
-#else // compiler
-#error compiler not recognized
-#endif // compiler
+
+WARNING_POP
 
 TML_INLINE FractionalDataType ComputeSmallChangeInRegressionPredictionForOneSegment(const FractionalDataType sumResidualError, const size_t cCases) {
    // TODO: check again if we can ever have a zero here

--- a/src/core/ebmcore/EbmStatistics.h
+++ b/src/core/ebmcore/EbmStatistics.h
@@ -26,11 +26,11 @@ public:
    WARNING_PUSH
    WARNING_DISABLE_POTENTIAL_DIVIDE_BY_ZERO
    TML_INLINE static FractionalDataType ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(const FractionalDataType sumResidualError, const FractionalDataType sumDenominator) {
-      if(LIKELY(static_cast<FractionalDataType>(0) != sumDenominator)) {
+      if(LIKELY(FractionalDataType { 0 } != sumDenominator)) {
          // this is a very predictable branch, so we'd prefer this to be an actual branch rather than an unpredictable one
          return sumResidualError / sumDenominator;
       } else {
-         return static_cast<FractionalDataType>(0);
+         return FractionalDataType { 0 };
       }
    }
    WARNING_POP
@@ -78,15 +78,15 @@ public:
 
    TML_INLINE static FractionalDataType ComputeClassificationResidualErrorMulticlass(const FractionalDataType sumExp, const FractionalDataType trainingLogWeight, const StorageDataTypeCore binnedActualValue, const StorageDataTypeCore iVector) {
       // TODO: is it better to use the non-branching conditional below, or is it better to assign all the items the negation case and then AFTERWARDS adding one to the single case that is equal to iVector 
-      const FractionalDataType yi = UNPREDICTABLE(iVector == binnedActualValue) ? static_cast<FractionalDataType>(1) : static_cast<FractionalDataType>(0);
+      const FractionalDataType yi = UNPREDICTABLE(iVector == binnedActualValue) ? FractionalDataType { 1 } : static_cast<FractionalDataType>(0);
       const FractionalDataType ret = yi - std::exp(trainingLogWeight) / sumExp;
       return ret;
    }
 
    // if trainingLogWeight is zero, we can call this simpler function
    TML_INLINE static FractionalDataType ComputeClassificationResidualErrorMulticlass(const bool isMatch, const FractionalDataType sumExp) {
-      const FractionalDataType yi = UNPREDICTABLE(isMatch) ? static_cast<FractionalDataType>(1) : static_cast<FractionalDataType>(0);
-      const FractionalDataType ret = yi - static_cast<FractionalDataType>(1) / sumExp;
+      const FractionalDataType yi = UNPREDICTABLE(isMatch) ? FractionalDataType { 1 } : FractionalDataType { 0 };
+      const FractionalDataType ret = yi - FractionalDataType { 1 } / sumExp;
 
       EBM_ASSERT(!isMatch || ComputeClassificationResidualErrorMulticlass(sumExp, 0, 1, 1) == ret);
       EBM_ASSERT(isMatch || ComputeClassificationResidualErrorMulticlass(sumExp, 0, 1, 2) == ret);

--- a/src/core/ebmcore/InitializeResiduals.h
+++ b/src/core/ebmcore/InitializeResiduals.h
@@ -44,7 +44,7 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
             EBM_ASSERT(!std::isnan(data));
             EBM_ASSERT(!std::isinf(data));
             const FractionalDataType predictionScore = 0;
-            const FractionalDataType residualError = ComputeRegressionResidualError(predictionScore, data);
+            const FractionalDataType residualError = EbmStatistics::ComputeRegressionResidualError(predictionScore, data);
             EBM_ASSERT(*pResidualError == residualError);
             ++pTargetData;
             ++pResidualError;
@@ -55,8 +55,8 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
 
          const IntegerDataType * pTargetData = static_cast<const IntegerDataType *>(aTargetData);
 
-         const FractionalDataType matchValue = ComputeClassificationResidualErrorMulticlass(true, static_cast<FractionalDataType>(cVectorLength));
-         const FractionalDataType nonMatchValue = ComputeClassificationResidualErrorMulticlass(false, static_cast<FractionalDataType>(cVectorLength));
+         const FractionalDataType matchValue = EbmStatistics::ComputeClassificationResidualErrorMulticlass(true, static_cast<FractionalDataType>(cVectorLength));
+         const FractionalDataType nonMatchValue = EbmStatistics::ComputeClassificationResidualErrorMulticlass(false, static_cast<FractionalDataType>(cVectorLength));
 
          EBM_ASSERT((IsNumberConvertable<StorageDataTypeCore, size_t>(cVectorLength)));
          const StorageDataTypeCore cVectorLengthStorage = static_cast<StorageDataTypeCore>(cVectorLength);
@@ -70,13 +70,13 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
             EBM_ASSERT(data < static_cast<StorageDataTypeCore>(cTargetStates));
 
             if(IsBinaryClassification(countCompilerClassificationTargetStates)) {
-               const FractionalDataType residualError = ComputeClassificationResidualErrorBinaryclass(data);
+               const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorBinaryclass(data);
                *pResidualError = residualError;
                ++pResidualError;
             } else {
                for(StorageDataTypeCore iVector = 0; iVector < cVectorLengthStorage; ++iVector) {
-                  const FractionalDataType residualError = ComputeClassificationResidualErrorMulticlass(data, iVector, matchValue, nonMatchValue);
-                  EBM_ASSERT(ComputeClassificationResidualErrorMulticlass(static_cast<FractionalDataType>(cVectorLength), 0, data, iVector) == residualError);
+                  const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorMulticlass(data, iVector, matchValue, nonMatchValue);
+                  EBM_ASSERT(EbmStatistics::ComputeClassificationResidualErrorMulticlass(static_cast<FractionalDataType>(cVectorLength), 0, data, iVector) == residualError);
                   *pResidualError = residualError;
                   ++pResidualError;
                }
@@ -105,7 +105,7 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
             EBM_ASSERT(!std::isnan(data));
             EBM_ASSERT(!std::isinf(data));
             const FractionalDataType predictionScore = *pPredictionScores;
-            const FractionalDataType residualError = ComputeRegressionResidualError(predictionScore, data);
+            const FractionalDataType residualError = EbmStatistics::ComputeRegressionResidualError(predictionScore, data);
             *pResidualError = residualError;
             ++pTargetData;
             ++pPredictionScores;
@@ -129,7 +129,7 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
 
             if(IsBinaryClassification(countCompilerClassificationTargetStates)) {
                const FractionalDataType predictionScore = *pPredictionScores;
-               const FractionalDataType residualError = ComputeClassificationResidualErrorBinaryclass(predictionScore, data);
+               const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorBinaryclass(predictionScore, data);
                *pResidualError = residualError;
                ++pPredictionScores;
                ++pResidualError;
@@ -150,7 +150,7 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
                for(StorageDataTypeCore iVector = 0; iVector < cVectorLengthStorage; ++iVector) {
                   const FractionalDataType predictionScore = *pPredictionScores - subtract;
                   // TODO : we're calculating exp(predictionScore) above, and then again in ComputeClassificationResidualErrorMulticlass.  exp(..) is expensive so we should just do it once instead and store the result in a small memory array here
-                  const FractionalDataType residualError = ComputeClassificationResidualErrorMulticlass(sumExp, predictionScore, data, iVector);
+                  const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorMulticlass(sumExp, predictionScore, data, iVector);
                   *pResidualError = residualError;
                   ++pPredictionScores;
                   ++pResidualError;
@@ -173,18 +173,6 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
       }
    }
    LOG(TraceLevelInfo, "Exited InitializeResiduals");
-}
-
-TML_INLINE static void InitializeResidualsFlat(const bool bRegression, const size_t cCases, const void * const aTargetData, const FractionalDataType * const aPredictionScores, FractionalDataType * pResidualError, const size_t cTargetStates) {
-   if(bRegression) {
-      InitializeResiduals<k_Regression>(cCases, aTargetData, aPredictionScores, pResidualError, 0);
-   } else {
-      if(2 == cTargetStates) {
-         InitializeResiduals<2>(cCases, aTargetData, aPredictionScores, pResidualError, 2);
-      } else {
-         InitializeResiduals<k_DynamicClassification>(cCases, aTargetData, aPredictionScores, pResidualError, cTargetStates);
-      }
-   }
 }
 
 #endif // INITIALIZE_RESIDUALS_H

--- a/src/core/ebmcore/InitializeResiduals.h
+++ b/src/core/ebmcore/InitializeResiduals.h
@@ -90,7 +90,7 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
                constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
                if(bZeroingResiduals) {
-                  pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLength)] = 0;
+                  pResidualError[k_iZeroResidual - static_cast<ptrdiff_t>(cVectorLength)] = 0;
                }
             }
             ++pTargetData;
@@ -165,7 +165,7 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
                constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
                if(bZeroingResiduals) {
-                  pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLengthStorage)] = 0;
+                  pResidualError[k_iZeroResidual - static_cast<ptrdiff_t>(cVectorLengthStorage)] = 0;
                }
             }
             ++pTargetData;

--- a/src/core/ebmcore/InitializeResiduals.h
+++ b/src/core/ebmcore/InitializeResiduals.h
@@ -88,7 +88,8 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
                // insted of allowing them to be scaled.  
                // Probability = exp(T1 + I1) / [exp(T1 + I1) + exp(T2 + I2) + exp(T3 + I3)] => we can add a constant inside each exp(..) term, which will be multiplication outside the exp(..), which
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
-               if(0 <= k_iZeroResidual) {
+               constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
+               if(bZeroingResiduals) {
                   pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLength)] = 0;
                }
             }
@@ -162,7 +163,8 @@ static void InitializeResiduals(const size_t cCases, const void * const aTargetD
                // insted of allowing them to be scaled.  
                // Probability = exp(T1 + I1) / [exp(T1 + I1) + exp(T2 + I2) + exp(T3 + I3)] => we can add a constant inside each exp(..) term, which will be multiplication outside the exp(..), which
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
-               if(0 <= k_iZeroResidual) {
+               constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
+               if(bZeroingResiduals) {
                   pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLengthStorage)] = 0;
                }
             }

--- a/src/core/ebmcore/InteractionDetection.cpp
+++ b/src/core/ebmcore/InteractionDetection.cpp
@@ -224,7 +224,7 @@ EBMCORE_IMPORT_EXPORT IntegerDataType EBMCORE_CALLING_CONVENTION GetInteractionS
 
    LOG_COUNTED(&pEbmInteractionState->m_cLogEnterMessages, TraceLevelInfo, TraceLevelVerbose, "Entered GetInteractionScore");
 
-   EBM_ASSERT(1 <= countAttributesInCombination);
+   EBM_ASSERT(0 <= countAttributesInCombination);
    EBM_ASSERT(nullptr != attributeIndexes);
 
    if(!IsNumberConvertable<size_t, IntegerDataType>(countAttributesInCombination)) {

--- a/src/core/ebmcore/InteractionDetection.cpp
+++ b/src/core/ebmcore/InteractionDetection.cpp
@@ -202,8 +202,6 @@ TML_INLINE IntegerDataType CompilerRecursiveGetInteractionScore(const size_t cRu
    }
 }
 
-WARNING_PUSH
-WARNING_DISABLE_UNREFERENCED_PARAMETER
 template<>
 TML_INLINE IntegerDataType CompilerRecursiveGetInteractionScore<k_cCompilerOptimizedTargetStatesMax + 1>(const size_t cRuntimeTargetStates, TmlInteractionState * const pEbmInteractionState, const AttributeCombinationCore * const pAttributeCombination, FractionalDataType * const pInteractionScoreReturn) {
    UNUSED(cRuntimeTargetStates);
@@ -211,7 +209,6 @@ TML_INLINE IntegerDataType CompilerRecursiveGetInteractionScore<k_cCompilerOptim
    EBM_ASSERT(k_cCompilerOptimizedTargetStatesMax < cRuntimeTargetStates || 1 == cRuntimeTargetStates);
    return GetInteractionScorePerTargetStates<k_DynamicClassification>(pEbmInteractionState, pAttributeCombination, pInteractionScoreReturn);
 }
-WARNING_POP
 
 // we made this a global because if we had put this variable inside the TmlInteractionState object, then we would need to dereference that before getting the count.  By making this global we can send a log message incase a bad TmlInteractionState object is sent into us
 // we only decrease the count if the count is non-zero, so at worst if there is a race condition then we'll output this log message more times than desired, but we can live with that

--- a/src/core/ebmcore/InteractionDetection.cpp
+++ b/src/core/ebmcore/InteractionDetection.cpp
@@ -206,6 +206,7 @@ WARNING_PUSH
 WARNING_DISABLE_UNREFERENCED_PARAMETER
 template<>
 TML_INLINE IntegerDataType CompilerRecursiveGetInteractionScore<k_cCompilerOptimizedTargetStatesMax + 1>(const size_t cRuntimeTargetStates, TmlInteractionState * const pEbmInteractionState, const AttributeCombinationCore * const pAttributeCombination, FractionalDataType * const pInteractionScoreReturn) {
+   UNUSED(cRuntimeTargetStates);
    // it is logically possible, but uninteresting to have a classification with 1 target state, so let our runtime system handle those unlikley and uninteresting cases
    EBM_ASSERT(k_cCompilerOptimizedTargetStatesMax < cRuntimeTargetStates || 1 == cRuntimeTargetStates);
    return GetInteractionScorePerTargetStates<k_DynamicClassification>(pEbmInteractionState, pAttributeCombination, pInteractionScoreReturn);

--- a/src/core/ebmcore/Logging.cpp
+++ b/src/core/ebmcore/Logging.cpp
@@ -31,6 +31,8 @@ EBMCORE_IMPORT_EXPORT void EBMCORE_CALLING_CONVENTION SetTraceLevel(signed char 
    g_traceLevel = traceLevel;
 }
 
+WARNING_PUSH
+WARNING_DISABLE_NON_LITERAL_PRINTF_STRING
 extern void InteralLogWithArguments(signed char traceLevel, const char * const pOriginalMessage, ...) {
    // this function is here largely to clip the stack memory needed for messageSpace.  If we put the below functionality directly into a MACRO or an inline function then the 
    // memory gets reserved on the stack of the function which calls our logging MACRO.  The reserved memory will be held when our calling function calls any
@@ -50,3 +52,4 @@ extern void InteralLogWithArguments(signed char traceLevel, const char * const p
    }
    va_end(args);
 }
+WARNING_POP

--- a/src/core/ebmcore/Logging.h
+++ b/src/core/ebmcore/Logging.h
@@ -30,7 +30,8 @@ extern const char g_assertLogMessage[];
          assert(nullptr != g_pLogMessageFunc); \
          constexpr size_t LOG__cArguments = std::tuple_size<decltype(std::make_tuple(__VA_ARGS__))>::value; \
          constexpr static char LOG__originalMessage[] = (pLogMessage); /* we only use pLogMessage once, which avoids pre and post decrement issues with macros */ \
-         if(0 == LOG__cArguments) { /* if there are no arguments we might as well send the log directly without reserving stack space for vsnprintf and without log length limitations for stack allocation */ \
+         constexpr bool bZeroArguments = 0 == LOG__cArguments; \
+         if(bZeroArguments) { /* if there are no arguments we might as well send the log directly without reserving stack space for vsnprintf and without log length limitations for stack allocation */ \
             (*g_pLogMessageFunc)(LOG__traceLevel, LOG__originalMessage); \
          } else { \
             InteralLogWithArguments(LOG__traceLevel, LOG__originalMessage, ##__VA_ARGS__); \
@@ -50,13 +51,14 @@ extern const char g_assertLogMessage[];
       static_assert(LOG__traceLevelBefore < LOG__traceLevelAfter, "We only support increasing the required trace level after N iterations and it doesn't make sense to have equal values, otherwise just use LOG(..)"); \
       if(UNLIKELY(LOG__traceLevelBefore <= g_traceLevel)) { \
          constexpr size_t LOG__cArguments = std::tuple_size<decltype(std::make_tuple(__VA_ARGS__))>::value; \
+         constexpr bool bZeroArguments = 0 == LOG__cArguments; \
          constexpr static char LOG__originalMessage[] = (pLogMessage); /* we only use pLogMessage once, which avoids pre and post decrement issues with macros */ \
          unsigned int * const LOG__pLogCountDecrement = (pLogCountDecrement); /* we only use pLogCountDecrement once, which avoids pre and post decrement issues with macros */ \
          const unsigned int LOG__logCount = *LOG__pLogCountDecrement; \
          if(0 < LOG__logCount) { \
             *LOG__pLogCountDecrement = LOG__logCount - 1; \
             assert(nullptr != g_pLogMessageFunc); \
-            if(0 == LOG__cArguments) { /* if there are no arguments we might as well send the log directly without reserving stack space for vsnprintf and without log length limitations for stack allocation */ \
+            if(bZeroArguments) { /* if there are no arguments we might as well send the log directly without reserving stack space for vsnprintf and without log length limitations for stack allocation */ \
                (*g_pLogMessageFunc)(LOG__traceLevelBefore, LOG__originalMessage); \
             } else { \
                InteralLogWithArguments(LOG__traceLevelBefore, LOG__originalMessage, ##__VA_ARGS__); \
@@ -64,7 +66,7 @@ extern const char g_assertLogMessage[];
          } else { \
             if(UNLIKELY(LOG__traceLevelAfter <= g_traceLevel)) { \
                assert(nullptr != g_pLogMessageFunc); \
-               if(0 == LOG__cArguments) { /* if there are no arguments we might as well send the log directly without reserving stack space for vsnprintf and without log length limitations for stack allocation */ \
+               if(bZeroArguments) { /* if there are no arguments we might as well send the log directly without reserving stack space for vsnprintf and without log length limitations for stack allocation */ \
                   (*g_pLogMessageFunc)(LOG__traceLevelAfter, LOG__originalMessage); \
                } else { \
                   InteralLogWithArguments(LOG__traceLevelAfter, LOG__originalMessage, ##__VA_ARGS__); \

--- a/src/core/ebmcore/Logging.h
+++ b/src/core/ebmcore/Logging.h
@@ -81,7 +81,7 @@ extern const char g_assertLogMessage[];
 // the "assert(!#bCondition)" condition needs some explanation.  At that point we definetly want to assert false, and we also want to include the text of the assert that triggered the failure.
 // Any string will have a non-zero pointer, so negating it will always fail, and we'll get to see the text of the original failure in the message
 // this allows us to use whatever behavior has been chosen by the C runtime library implementor for assertion failures without using the undocumented function that assert calls internally on each platform
-#define EBM_ASSERT(bCondition) ((void)(UNLIKELY(bCondition) ? 0 : (assert(UNLIKELY(nullptr != g_pLogMessageFunc)), UNLIKELY(TraceLevelError <= g_traceLevel) ? (InteralLogWithArguments(TraceLevelError, g_assertLogMessage, static_cast<unsigned long long>(__LINE__), __FILE__, __func__, #bCondition), 0) : 0, assert(!#bCondition), 0)))
+#define EBM_ASSERT(bCondition) ((void)(UNLIKELY(bCondition) ? 0 : (assert(UNLIKELY(nullptr != g_pLogMessageFunc)), UNLIKELY(TraceLevelError <= g_traceLevel) ? (InteralLogWithArguments(TraceLevelError, g_assertLogMessage, static_cast<unsigned long long>(__LINE__), __FILE__, __func__, #bCondition), 0) : 0, assert(!   #bCondition), 0)))
 #else // NDEBUG
 #define EBM_ASSERT(bCondition) ((void)0)
 #endif // NDEBUG

--- a/src/core/ebmcore/MultiDimensionalTraining.h
+++ b/src/core/ebmcore/MultiDimensionalTraining.h
@@ -874,9 +874,9 @@ FractionalDataType SweepMultiDiemensional(const BinnedBucket<IsRegression(countC
 
       FractionalDataType splittingScore = 0;
       for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
-         splittingScore += 0 == pTotalsLow->cCasesInBucket ? 0 : ComputeNodeSplittingScore(pTotalsLow->aPredictionStatistics[iVector].sumResidualError, pTotalsLow->cCasesInBucket);
+         splittingScore += 0 == pTotalsLow->cCasesInBucket ? 0 : EbmStatistics::ComputeNodeSplittingScore(pTotalsLow->aPredictionStatistics[iVector].sumResidualError, pTotalsLow->cCasesInBucket);
          EBM_ASSERT(0 <= splittingScore);
-         splittingScore += 0 == pTotalsHigh->cCasesInBucket ? 0 : ComputeNodeSplittingScore(pTotalsHigh->aPredictionStatistics[iVector].sumResidualError, pTotalsHigh->cCasesInBucket);
+         splittingScore += 0 == pTotalsHigh->cCasesInBucket ? 0 : EbmStatistics::ComputeNodeSplittingScore(pTotalsHigh->aPredictionStatistics[iVector].sumResidualError, pTotalsHigh->cCasesInBucket);
          EBM_ASSERT(0 <= splittingScore);
       }
       EBM_ASSERT(0 <= splittingScore);
@@ -1272,17 +1272,17 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
 
             if(IsRegression(countCompilerClassificationTargetStates)) {
                // regression
-               predictionLowLow = 0 == pTotals2LowLowBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowLowBest->cCasesInBucket);
-               predictionLowHigh = 0 == pTotals2LowHighBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowHighBest->cCasesInBucket);
-               predictionHighLow = 0 == pTotals2HighLowBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighLowBest->cCasesInBucket);
-               predictionHighHigh = 0 == pTotals2HighHighBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighHighBest->cCasesInBucket);
+               predictionLowLow = 0 == pTotals2LowLowBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowLowBest->cCasesInBucket);
+               predictionLowHigh = 0 == pTotals2LowHighBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowHighBest->cCasesInBucket);
+               predictionHighLow = 0 == pTotals2HighLowBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighLowBest->cCasesInBucket);
+               predictionHighHigh = 0 == pTotals2HighHighBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals2HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighHighBest->cCasesInBucket);
             } else {
                // classification
                EBM_ASSERT(IsClassification(countCompilerClassificationTargetStates));
-               predictionLowLow = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowLowBest->aPredictionStatistics[iVector].GetSumDenominator());
-               predictionLowHigh = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowHighBest->aPredictionStatistics[iVector].GetSumDenominator());
-               predictionHighLow = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighLowBest->aPredictionStatistics[iVector].GetSumDenominator());
-               predictionHighHigh = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighHighBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionLowLow = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowLowBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionLowHigh = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2LowHighBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionHighLow = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighLowBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionHighHigh = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals2HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals2HighHighBest->aPredictionStatistics[iVector].GetSumDenominator());
             }
 
             if(cutFirst2LowBest < cutFirst2HighBest) {
@@ -1378,17 +1378,17 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
 
             if(IsRegression(countCompilerClassificationTargetStates)) {
                // regression
-               predictionLowLow = 0 == pTotals1LowLowBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowLowBest->cCasesInBucket);
-               predictionLowHigh = 0 == pTotals1LowHighBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowHighBest->cCasesInBucket);
-               predictionHighLow = 0 == pTotals1HighLowBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighLowBest->cCasesInBucket);
-               predictionHighHigh = 0 == pTotals1HighHighBest->cCasesInBucket ? 0 : ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighHighBest->cCasesInBucket);
+               predictionLowLow = 0 == pTotals1LowLowBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowLowBest->cCasesInBucket);
+               predictionLowHigh = 0 == pTotals1LowHighBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowHighBest->cCasesInBucket);
+               predictionHighLow = 0 == pTotals1HighLowBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighLowBest->cCasesInBucket);
+               predictionHighHigh = 0 == pTotals1HighHighBest->cCasesInBucket ? 0 : EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pTotals1HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighHighBest->cCasesInBucket);
             } else {
                EBM_ASSERT(IsClassification(countCompilerClassificationTargetStates));
                // classification
-               predictionLowLow = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowLowBest->aPredictionStatistics[iVector].GetSumDenominator());
-               predictionLowHigh = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowHighBest->aPredictionStatistics[iVector].GetSumDenominator());
-               predictionHighLow = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighLowBest->aPredictionStatistics[iVector].GetSumDenominator());
-               predictionHighHigh = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighHighBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionLowLow = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1LowLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowLowBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionLowHigh = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1LowHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1LowHighBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionHighLow = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1HighLowBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighLowBest->aPredictionStatistics[iVector].GetSumDenominator());
+               predictionHighHigh = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pTotals1HighHighBest->aPredictionStatistics[iVector].sumResidualError, pTotals1HighHighBest->aPredictionStatistics[iVector].GetSumDenominator());
             }
 
             if(cutFirst1LowBest < cutFirst1HighBest) {
@@ -1856,10 +1856,10 @@ bool CalculateInteractionScore(const size_t cTargetStates, CachedInteractionThre
 
             FractionalDataType splittingScore = 0;
             for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
-               splittingScore += 0 == pTotalsLowLow->cCasesInBucket ? 0 : ComputeNodeSplittingScore(pTotalsLowLow->aPredictionStatistics[iVector].sumResidualError, pTotalsLowLow->cCasesInBucket);
-               splittingScore += 0 == pTotalsLowHigh->cCasesInBucket ? 0 : ComputeNodeSplittingScore(pTotalsLowHigh->aPredictionStatistics[iVector].sumResidualError, pTotalsLowHigh->cCasesInBucket);
-               splittingScore += 0 == pTotalsHighLow->cCasesInBucket ? 0 : ComputeNodeSplittingScore(pTotalsHighLow->aPredictionStatistics[iVector].sumResidualError, pTotalsHighLow->cCasesInBucket);
-               splittingScore += 0 == pTotalsHighHigh->cCasesInBucket ? 0 : ComputeNodeSplittingScore(pTotalsHighHigh->aPredictionStatistics[iVector].sumResidualError, pTotalsHighHigh->cCasesInBucket);
+               splittingScore += 0 == pTotalsLowLow->cCasesInBucket ? 0 : EbmStatistics::ComputeNodeSplittingScore(pTotalsLowLow->aPredictionStatistics[iVector].sumResidualError, pTotalsLowLow->cCasesInBucket);
+               splittingScore += 0 == pTotalsLowHigh->cCasesInBucket ? 0 : EbmStatistics::ComputeNodeSplittingScore(pTotalsLowHigh->aPredictionStatistics[iVector].sumResidualError, pTotalsLowHigh->cCasesInBucket);
+               splittingScore += 0 == pTotalsHighLow->cCasesInBucket ? 0 : EbmStatistics::ComputeNodeSplittingScore(pTotalsHighLow->aPredictionStatistics[iVector].sumResidualError, pTotalsHighLow->cCasesInBucket);
+               splittingScore += 0 == pTotalsHighHigh->cCasesInBucket ? 0 : EbmStatistics::ComputeNodeSplittingScore(pTotalsHighHigh->aPredictionStatistics[iVector].sumResidualError, pTotalsHighHigh->cCasesInBucket);
                EBM_ASSERT(0 <= splittingScore);
             }
             EBM_ASSERT(0 <= splittingScore);

--- a/src/core/ebmcore/MultiDimensionalTraining.h
+++ b/src/core/ebmcore/MultiDimensionalTraining.h
@@ -99,7 +99,7 @@ void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificat
    }
 
    BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pComparison2 = static_cast<BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> *>(malloc(cBytesPerBinnedBucket));
-   if(nullptr != pComparison) {
+   if(nullptr != pComparison2) {
       // if we can't obtain the memory, then don't do the comparison and exit
       GetTotalsDebugSlow<countCompilerClassificationTargetStates, countCompilerDimensions>(aBinnedBuckets, pAttributeCombination, aiStart, aiLast, cTargetStates, pComparison2);
       EBM_ASSERT(pComparison->cCasesInBucket == pComparison2->cCasesInBucket);

--- a/src/core/ebmcore/MultiDimensionalTraining.h
+++ b/src/core/ebmcore/MultiDimensionalTraining.h
@@ -78,7 +78,6 @@ void GetTotalsDebugSlow(const BinnedBucket<IsRegression(countCompilerClassificat
 // TODO: remove the templating on these debug functions.  We don't need to replicate this function 63 times!!
 template<ptrdiff_t countCompilerClassificationTargetStates, size_t countCompilerDimensions>
 void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const aBinnedBuckets, const AttributeCombinationCore * const pAttributeCombination, const size_t * const aiPoint, const size_t directionVector, const size_t cTargetStates, const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pComparison) {
-   const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
    const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
@@ -158,7 +157,7 @@ void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificat
 //
 //   static_assert(k_cDimensionsMax < k_cBitsForSizeT, "reserve the highest bit for bit manipulation space");
 //   EBM_ASSERT(cDimensions < k_cBitsForSizeT);
-//   const size_t permuteVectorEnd = static_cast<size_t>(1) << cDimensions;
+//   const size_t permuteVectorEnd = size_t { 1 } << cDimensions;
 //   BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * pBinnedBucket = aBinnedBuckets;
 //
 //   goto skip_intro;
@@ -289,7 +288,7 @@ void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificat
 //
 //   static_assert(k_cDimensionsMax < k_cBitsForSizeT, "reserve the highest bit for bit manipulation space");
 //   EBM_ASSERT(cDimensions < k_cBitsForSizeT);
-//   const size_t permuteVectorEnd = static_cast<size_t>(1) << cDimensions;
+//   const size_t permuteVectorEnd = size_t { 1 } << cDimensions;
 //   BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * pBinnedBucket = aBinnedBuckets;
 //
 //   goto skip_intro;
@@ -572,7 +571,7 @@ void BuildFastTotalsZeroMemoryIncrease(BinnedBucket<IsRegression(countCompilerCl
    static_assert(k_cDimensionsMax < k_cBitsForSizeTCore, "reserve the highest bit for bit manipulation space");
    EBM_ASSERT(cDimensions < k_cBitsForSizeTCore);
    EBM_ASSERT(2 <= cDimensions);
-   const size_t permuteVectorEnd = static_cast<size_t>(1) << (cDimensions - 1);
+   const size_t permuteVectorEnd = size_t { 1 } << (cDimensions - 1);
    BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * pBinnedBucket = aBinnedBuckets;
    
    ptrdiff_t multipliedIndexCur0 = 0;
@@ -832,7 +831,7 @@ FractionalDataType SweepMultiDiemensional(const BinnedBucket<IsRegression(countC
 
    EBM_ASSERT(1 <= pAttributeCombination->m_cAttributes);
    EBM_ASSERT(iDimensionSweep < pAttributeCombination->m_cAttributes);
-   EBM_ASSERT(0 == (directionVectorLow & (static_cast<size_t>(1) << iDimensionSweep)));
+   EBM_ASSERT(0 == (directionVectorLow & (size_t { 1 } << iDimensionSweep)));
 
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
@@ -842,7 +841,7 @@ FractionalDataType SweepMultiDiemensional(const BinnedBucket<IsRegression(countC
 
    size_t * const piPoint = &aiPoint[iDimensionSweep];
    *piPoint = 0;
-   size_t directionVectorHigh = directionVectorLow | static_cast<size_t>(1) << iDimensionSweep;
+   size_t directionVectorHigh = directionVectorLow | size_t { 1 } << iDimensionSweep;
 
    const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimensionSweep].m_pAttribute->m_cStates;
    EBM_ASSERT(2 <= cStates);

--- a/src/core/ebmcore/MultiDimensionalTraining.h
+++ b/src/core/ebmcore/MultiDimensionalTraining.h
@@ -20,14 +20,17 @@
 
 #ifndef NDEBUG
 
+// TODO: remove the templating on these debug functions.  We don't need to replicate this function 63 times!!
 template<ptrdiff_t countCompilerClassificationTargetStates, size_t countCompilerDimensions>
 void GetTotalsDebugSlow(const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const aBinnedBuckets, const AttributeCombinationCore * const pAttributeCombination, const size_t * const aiStart, const size_t * const aiLast, const size_t cTargetStates, BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pRet) {
    const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
+   EBM_ASSERT(1 <= cDimensions); // why bother getting totals if we just have 1 bin
    size_t aiDimensions[k_cDimensionsMax];
 
    size_t iBin = 0;
    size_t valueMultipleInitialize = 1;
-   for(size_t iDimensionInitialize = 0; iDimensionInitialize < cDimensions; ++iDimensionInitialize) {
+   size_t iDimensionInitialize = 0;
+   do {
       const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimensionInitialize].m_pAttribute->m_cStates;
       EBM_ASSERT(aiStart[iDimensionInitialize] < cStates);
       EBM_ASSERT(aiLast[iDimensionInitialize] < cStates);
@@ -37,7 +40,8 @@ void GetTotalsDebugSlow(const BinnedBucket<IsRegression(countCompilerClassificat
       EBM_ASSERT(!IsMultiplyError(cStates, valueMultipleInitialize)); // we've allocated this memory, so it should be reachable, so these numbers should multiply
       valueMultipleInitialize *= cStates;
       aiDimensions[iDimensionInitialize] = aiStart[iDimensionInitialize];
-   }
+      ++iDimensionInitialize;
+   } while(iDimensionInitialize < cDimensions);
 
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we've allocated this, so it should fit
@@ -71,8 +75,9 @@ void GetTotalsDebugSlow(const BinnedBucket<IsRegression(countCompilerClassificat
    }
 }
 
+// TODO: remove the templating on these debug functions.  We don't need to replicate this function 63 times!!
 template<ptrdiff_t countCompilerClassificationTargetStates, size_t countCompilerDimensions>
-void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const aBinnedBuckets, const AttributeCombinationCore * const pAttributeCombination, const size_t * const aiPoint, const size_t directionVector, const size_t cTargetStates, const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pRet) {
+void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const aBinnedBuckets, const AttributeCombinationCore * const pAttributeCombination, const size_t * const aiPoint, const size_t directionVector, const size_t cTargetStates, const BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pComparison) {
    const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
@@ -93,12 +98,12 @@ void CompareTotalsDebug(const BinnedBucket<IsRegression(countCompilerClassificat
       directionVectorDestroy >>= 1;
    }
 
-   BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pComparison = static_cast<BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> *>(malloc(cBytesPerBinnedBucket));
+   BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pComparison2 = static_cast<BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> *>(malloc(cBytesPerBinnedBucket));
    if(nullptr != pComparison) {
       // if we can't obtain the memory, then don't do the comparison and exit
-      GetTotalsDebugSlow<countCompilerClassificationTargetStates, countCompilerDimensions>(aBinnedBuckets, pAttributeCombination, aiStart, aiLast, cTargetStates, pComparison);
-      EBM_ASSERT(pRet->cCasesInBucket == pComparison->cCasesInBucket);
-      free(pComparison);
+      GetTotalsDebugSlow<countCompilerClassificationTargetStates, countCompilerDimensions>(aBinnedBuckets, pAttributeCombination, aiStart, aiLast, cTargetStates, pComparison2);
+      EBM_ASSERT(pComparison->cCasesInBucket == pComparison2->cCasesInBucket);
+      free(pComparison2);
    }
 }
 
@@ -389,6 +394,8 @@ void BuildFastTotals(BinnedBucket<IsRegression(countCompilerClassificationTarget
    LOG(TraceLevelVerbose, "Entered BuildFastTotals");
 
    const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
+   EBM_ASSERT(1 <= cDimensions);
+
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
    const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
@@ -528,6 +535,8 @@ void BuildFastTotalsZeroMemoryIncrease(BinnedBucket<IsRegression(countCompilerCl
    // TODO: sort our N-dimensional combinations at program startup so that the longest dimension is first!  That way we can more efficiently walk through contiguous memory better in this function!
 
    const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
+   EBM_ASSERT(1 <= cDimensions);
+
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
    const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
@@ -538,7 +547,7 @@ void BuildFastTotalsZeroMemoryIncrease(BinnedBucket<IsRegression(countCompilerCl
    {
       CurrentIndexAndCountStates * pCurrentIndexAndCountStatesInitialize = currentIndexAndCountStates;
       const AttributeCombinationCore::AttributeCombinationEntry * pAttributeCombinationEntry = &pAttributeCombination->m_AttributeCombinationEntry[0];
-      EBM_ASSERT(0 < cDimensions);
+      EBM_ASSERT(1 <= cDimensions);
       do {
          pCurrentIndexAndCountStatesInitialize->multipliedIndexCur = 0;
          EBM_ASSERT(1 <= pAttributeCombinationEntry->m_pAttribute->m_cStates); // this function can handle 1 == cStates even though that's a degenerate case that shouldn't be trained on (dimensions with 1 state don't contribute anything since they always have the same value)
@@ -697,14 +706,14 @@ void GetTotals(const BinnedBucket<IsRegression(countCompilerClassificationTarget
 ) {
    // don't LOG this!  It would create way too much chatter!
 
+   static_assert(k_cDimensionsMax < k_cBitsForSizeTCore, "reserve the highest bit for bit manipulation space");
    const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
+   EBM_ASSERT(1 <= cDimensions);
+   EBM_ASSERT(cDimensions < k_cBitsForSizeTCore);
+
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    EBM_ASSERT(!GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)); // we're accessing allocated memory
    const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
-
-   static_assert(k_cDimensionsMax < k_cBitsForSizeTCore, "reserve the highest bit for bit manipulation space");
-   EBM_ASSERT(cDimensions < k_cBitsForSizeTCore);
-   EBM_ASSERT(2 <= cDimensions);
 
    size_t multipleTotalInitialize = 1;
    size_t startingOffset = 0;
@@ -714,7 +723,7 @@ void GetTotals(const BinnedBucket<IsRegression(countCompilerClassificationTarget
 
    if(0 == directionVector) {
       // we would require a check in our inner loop below to handle the case of zero AttributeCombinationEntry items, so let's handle it separetly here instead
-      EBM_ASSERT(0 < cDimensions);
+      EBM_ASSERT(1 <= cDimensions);
       do {
          size_t cStates = pAttributeCombinationEntry->m_pAttribute->m_cStates;
          EBM_ASSERT(1 <= cStates); // this function can handle 1 == cStates even though that's a degenerate case that shouldn't be trained on (dimensions with 1 state don't contribute anything since they always have the same value)
@@ -821,6 +830,7 @@ FractionalDataType SweepMultiDiemensional(const BinnedBucket<IsRegression(countC
 
    // TODO : optimize this function
 
+   EBM_ASSERT(1 <= pAttributeCombination->m_cAttributes);
    EBM_ASSERT(iDimensionSweep < pAttributeCombination->m_cAttributes);
    EBM_ASSERT(0 == (directionVectorLow & (static_cast<size_t>(1) << iDimensionSweep)));
 
@@ -885,22 +895,26 @@ FractionalDataType SweepMultiDiemensional(const BinnedBucket<IsRegression(countC
 
 // TODO: consider adding controls to disallow cuts that would leave too few cases in a region
 // TODO: for higher dimensional spaces, we need to add/subtract individual cells alot and the denominator isn't required in order to make decisions about where to cut.  For dimensions higher than 2, we might want to copy the tensor to a new tensor AFTER binning that keeps only the residuals and then go back to our original tensor after splits to determine the denominator
+// TODO: do we really require countCompilerDimensions here?  Does it make any of the code below faster... or alternatively, should we puth the distinction down into a sub-function
 template<ptrdiff_t countCompilerClassificationTargetStates, size_t countCompilerDimensions>
 bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompilerClassificationTargetStates)> * const pCachedThreadResources, const SamplingMethod * const pTrainingSet, const AttributeCombinationCore * const pAttributeCombination, SegmentedRegionCore<ActiveDataType, FractionalDataType> * const pSmallChangeToModelOverwriteSingleSamplingSet, const size_t cTargetStates) {
    LOG(TraceLevelVerbose, "Entered TrainMultiDimensional");
 
+   // TODO: we can just re-generate this code 63 times and eliminate the dynamic cDimensions value.  We can also do this in several other places like for SegmentedRegion and other critical places
+   const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
+   EBM_ASSERT(2 <= cDimensions);
+
    size_t cAuxillaryBucketsForBuildFastTotals = 0;
    size_t cTotalBucketsMainSpace = 1;
-   for(size_t iDimension = 0; iDimension < pAttributeCombination->m_cAttributes; ++iDimension) {
+   for(size_t iDimension = 0; iDimension < cDimensions; ++iDimension) {
       const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimension].m_pAttribute->m_cStates;
-      EBM_ASSERT(1 <= cStates); // this function can handle 1 == cStates even though that's a degenerate case that shouldn't be trained on (dimensions with 1 state don't contribute anything since they always have the same value)
-      if(IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace)) {
-         LOG(TraceLevelWarning, "WARNING TrainMultiDimensional IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace)");
-         return true;
-      }
+      EBM_ASSERT(2 <= cStates); // we filer out 1 == cStates in allocation.  If cStates could be 1, then we'd need to check at runtime for overflow of cAuxillaryBucketsForBuildFastTotals
+      EBM_ASSERT(cAuxillaryBucketsForBuildFastTotals < cTotalBucketsMainSpace); // if this wasn't true then we'd have to check IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace) at runtime
+      EBM_ASSERT(!IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace)); // since cStates must be 2 or more, cAuxillaryBucketsForBuildFastTotals must grow slower than cTotalBucketsMainSpace, and we checked at allocation that cTotalBucketsMainSpace would not overflow
       cAuxillaryBucketsForBuildFastTotals += cTotalBucketsMainSpace;
       EBM_ASSERT(!IsMultiplyError(cTotalBucketsMainSpace, cStates)); // we check for simple multiplication overflow from m_cStates in TmlTrainingState->Initialize when we unpack attributeCombinationIndexes
       cTotalBucketsMainSpace *= cStates;
+      EBM_ASSERT(cAuxillaryBucketsForBuildFastTotals < cTotalBucketsMainSpace); // if this wasn't true then we'd have to check IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace) at runtime
    }
    const size_t cAuxillaryBucketsForSplitting = 24; // we need to reserve 4 PAST the pointer we pass into SweepMultiDiemensional!!!!.  We pass in index 20 at max, so we need 24
    const size_t cAuxillaryBuckets = cAuxillaryBucketsForBuildFastTotals < cAuxillaryBucketsForSplitting ? cAuxillaryBucketsForSplitting : cAuxillaryBucketsForBuildFastTotals;
@@ -935,7 +949,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
    const unsigned char * const aBinnedBucketsEndDebug = reinterpret_cast<unsigned char *>(aBinnedBuckets) + cBytesBuffer;
 #endif // NDEBUG
 
-   RecursiveBinDataSetTraining<countCompilerClassificationTargetStates, 2>::Recursive(pAttributeCombination->m_cAttributes, aBinnedBuckets, pAttributeCombination, pTrainingSet, cTargetStates
+   RecursiveBinDataSetTraining<countCompilerClassificationTargetStates, 2>::Recursive(cDimensions, aBinnedBuckets, pAttributeCombination, pTrainingSet, cTargetStates
 #ifndef NDEBUG
       , aBinnedBucketsEndDebug
 #endif // NDEBUG
@@ -944,7 +958,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
 #ifndef NDEBUG
    // make a copy of the original binned buckets for debugging purposes
    size_t cTotalBucketsDebug = 1;
-   for(size_t iDimensionDebug = 0; iDimensionDebug < pAttributeCombination->m_cAttributes; ++iDimensionDebug) {
+   for(size_t iDimensionDebug = 0; iDimensionDebug < cDimensions; ++iDimensionDebug) {
       const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimensionDebug].m_pAttribute->m_cStates;
       EBM_ASSERT(!IsMultiplyError(cTotalBucketsDebug, cStates)); // we checked this above
       cTotalBucketsDebug *= cStates;
@@ -963,9 +977,6 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
       , aBinnedBucketsDebugCopy, aBinnedBucketsEndDebug
 #endif // NDEBUG
    );
-
-   // TODO: we can just re-generate this code 63 times and eliminate the dynamic cDimensions value.  We can also do this in several other places like for SegmentedRegion and other critical places
-   const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
 
 
    //permutation0
@@ -1691,18 +1702,39 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
 
 template<ptrdiff_t countCompilerClassificationTargetStates, size_t countCompilerDimensions>
 bool CalculateInteractionScore(const size_t cTargetStates, CachedInteractionThreadResources * const pCachedThreadResources, const DataSetInternalCore * const pDataSet, const AttributeCombinationCore * const pAttributeCombination, FractionalDataType * const pInteractionScoreReturn) {
+   // TODO : we NEVER use the denominator term when calculating interaction scores, but we're calculating it and it's taking precious memory.  We should eliminate the denominator term HERE in our datastructures!!!
+
    LOG(TraceLevelVerbose, "Entered CalculateInteractionScore");
+
+   // TODO: we can just re-generate this code 63 times and eliminate the dynamic cDimensions value.  We can also do this in several other places like for SegmentedRegion and other critical places
+   const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
+   if(0 == cDimensions) {
+      // we could alternatively calculate the real interaction term by binning everying into one single bin, then calculating the score with ComputeNodeSplittingScore 
+      // BUT why would I do all that work.  In the end, we don't want to ever choose an interaction with zero attributes, so let's set it to zero, the lowest possible score
+      // so that it will never be selected by our calling framework.
+      *pInteractionScoreReturn = 0;
+      LOG(TraceLevelWarning, "WARNING Exited CalculateInteractionScore from zero dimensions.  Our caller should filter this out");
+      return false;
+   }
 
    size_t cAuxillaryBucketsForBuildFastTotals = 0;
    size_t cTotalBucketsMainSpace = 1;
-   for(size_t iDimension = 0; iDimension < pAttributeCombination->m_cAttributes; ++iDimension) {
+   for(size_t iDimension = 0; iDimension < cDimensions; ++iDimension) {
       const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimension].m_pAttribute->m_cStates;
-      EBM_ASSERT(1 <= cStates); // this function can handle 1 == cStates even though that's a degenerate case that shouldn't be trained on (dimensions with 1 state don't contribute anything since they always have the same value)
-      if(IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace)) {
-         LOG(TraceLevelWarning, "WARNING TrainMultiDimensional IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace)");
-         return true;
+      if(1 == cStates) {
+         // we could alternatively calculate the real interaction term by eliminating one dimension and then calculating the score on the reduced dimension representation, 
+         // which should be identical to how it would work without eliminating the one dimension
+         // BUT why would I do all that work.  In the end, we don't want to ever choose an interaction that has a dimension with 1 state since it should actually be processed with the reduced dimension combinations
+         // So let's set it to zero, the lowest possible score so that it will never be selected by our calling framework.
+         *pInteractionScoreReturn = 0;
+         LOG(TraceLevelWarning, "WARNING Exited CalculateInteractionScore from zero dimensions.  Our caller should filter this out");
+         return false;
       }
-      cAuxillaryBucketsForBuildFastTotals += cTotalBucketsMainSpace;
+
+      EBM_ASSERT(2 <= cStates); // we filer out 1 == cStates.  If cStates could be 1, then we'd need to check at runtime for overflow of cAuxillaryBucketsForBuildFastTotals
+      EBM_ASSERT(cAuxillaryBucketsForBuildFastTotals < cTotalBucketsMainSpace); // if this wasn't true then we'd have to check IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace) at runtime
+      EBM_ASSERT(!IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace)); // since cStates must be 2 or more, cAuxillaryBucketsForBuildFastTotals must grow slower than cTotalBucketsMainSpace, and we checked at allocation that cTotalBucketsMainSpace would not overflow
+      cAuxillaryBucketsForBuildFastTotals += cTotalBucketsMainSpace; // this can overflow, but if it does then we're guaranteed to catch the overflow via the multiplication check below
       if(IsMultiplyError(cTotalBucketsMainSpace, cStates)) {
          // unlike in the training code where we check at allocation time if the tensor created overflows on multiplication
          // we don't know what combination of features our caller will give us for calculating the interaction scores,
@@ -1711,7 +1743,9 @@ bool CalculateInteractionScore(const size_t cTargetStates, CachedInteractionThre
          return true;
       }
       cTotalBucketsMainSpace *= cStates;
+      EBM_ASSERT(cAuxillaryBucketsForBuildFastTotals < cTotalBucketsMainSpace); // if this wasn't true then we'd have to check IsAddError(cAuxillaryBucketsForBuildFastTotals, cTotalBucketsMainSpace) at runtime
    }
+
    const size_t cAuxillaryBucketsForSplitting = 4;
    const size_t cAuxillaryBuckets = cAuxillaryBucketsForBuildFastTotals < cAuxillaryBucketsForSplitting ? cAuxillaryBucketsForSplitting : cAuxillaryBucketsForBuildFastTotals;
    if(IsAddError(cTotalBucketsMainSpace, cAuxillaryBuckets)) {
@@ -1758,7 +1792,7 @@ bool CalculateInteractionScore(const size_t cTargetStates, CachedInteractionThre
 #ifndef NDEBUG
    // make a copy of the original binned buckets for debugging purposes
    size_t cTotalBucketsDebug = 1;
-   for(size_t iDimensionDebug = 0; iDimensionDebug < pAttributeCombination->m_cAttributes; ++iDimensionDebug) {
+   for(size_t iDimensionDebug = 0; iDimensionDebug < cDimensions; ++iDimensionDebug) {
       const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimensionDebug].m_pAttribute->m_cStates;
       EBM_ASSERT(!IsMultiplyError(cTotalBucketsDebug, cStates)); // we checked this above
       cTotalBucketsDebug *= cStates;
@@ -1778,8 +1812,6 @@ bool CalculateInteractionScore(const size_t cTargetStates, CachedInteractionThre
 #endif // NDEBUG
       );
 
-   // TODO: we can just re-generate this code 63 times and eliminate the dynamic cDimensions value.  We can also do this in several other places like for SegmentedRegion and other critical places
-   const size_t cDimensions = GET_ATTRIBUTE_COMBINATION_DIMENSIONS(countCompilerDimensions, pAttributeCombination->m_cAttributes);
    size_t aiStart[k_cDimensionsMax];
 
    if(2 == cDimensions) {
@@ -1846,14 +1878,11 @@ bool CalculateInteractionScore(const size_t cTargetStates, CachedInteractionThre
 
       *pInteractionScoreReturn = bestSplittingScore;
    } else {
+      EBM_ASSERT(false); // we only support pairs currently
       LOG(TraceLevelWarning, "WARNING CalculateInteractionScore 2 != cDimensions");
 
       // TODO: handle this better
-#ifndef NDEBUG
-      EBM_ASSERT(false); // we only support pairs currently
-      free(aBinnedBucketsDebugCopy);
-#endif // NDEBUG
-      return true;
+      *pInteractionScoreReturn = 0; // for now, just return any interactions that have other than 2 dimensions as zero, which means they won't be considered
    }
 
 #ifndef NDEBUG

--- a/src/core/ebmcore/MultiDimensionalTraining.h
+++ b/src/core/ebmcore/MultiDimensionalTraining.h
@@ -1191,7 +1191,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
       LOG(TraceLevelVerbose, "TrainMultiDimensional Done sweep loops");
 
       if(bCutFirst2) {
-         if (pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 1)) {
+         if(pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 1)) {
             LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 1)");
 #ifndef NDEBUG
             free(aBinnedBucketsDebugCopy);
@@ -1218,7 +1218,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(0)[0] = cutFirst2LowBest;
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(0)[1] = cutFirst2HighBest;
          } else if(cutFirst2HighBest < cutFirst2LowBest) {
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1235,7 +1235,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(0)[0] = cutFirst2HighBest;
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(0)[1] = cutFirst2LowBest;
          } else {
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(0, 1)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(0, 1)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(0, 1)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1243,7 +1243,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
                return true;
             }
 
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 4)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 4)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 4)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1296,7 +1296,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
             }
          }
       } else {
-         if (pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(0, 1)) {
+         if(pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(0, 1)) {
             LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(0, 1)");
 #ifndef NDEBUG
             free(aBinnedBucketsDebugCopy);
@@ -1306,7 +1306,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
          pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(0)[0] = cutFirst1Best;
 
          if(cutFirst1LowBest < cutFirst1HighBest) {
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1314,7 +1314,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
                return true;
             }
 
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 2)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 2)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 2)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1324,7 +1324,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(1)[0] = cutFirst1LowBest;
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(1)[1] = cutFirst1HighBest;
          } else if(cutFirst1HighBest < cutFirst1LowBest) {
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 6)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1332,7 +1332,7 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
                return true;
             }
 
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 2)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 2)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 2)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
@@ -1342,14 +1342,14 @@ bool TrainMultiDimensional(CachedTrainingThreadResources<IsRegression(countCompi
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(1)[0] = cutFirst1HighBest;
             pSmallChangeToModelOverwriteSingleSamplingSet->GetDivisionPointer(1)[1] = cutFirst1LowBest;
          } else {
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 1)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 1)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->SetCountDivisions(1, 1)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);
 #endif // NDEBUG
                return true;
             }
-            if (pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 4)) {
+            if(pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 4)) {
                LOG(TraceLevelWarning, "WARNING TrainMultiDimensional pSmallChangeToModelOverwriteSingleSamplingSet->EnsureValueCapacity(cVectorLength * 4)");
 #ifndef NDEBUG
                free(aBinnedBucketsDebugCopy);

--- a/src/core/ebmcore/PredictionStatistics.h
+++ b/src/core/ebmcore/PredictionStatistics.h
@@ -13,7 +13,7 @@
 #include "Logging.h" // EBM_ASSERT & LOG
 
 template<bool bRegression>
-class PredictionStatistics;
+struct PredictionStatistics;
 
 template<>
 struct PredictionStatistics<false> final {

--- a/src/core/ebmcore/PredictionStatistics.h
+++ b/src/core/ebmcore/PredictionStatistics.h
@@ -60,6 +60,7 @@ struct PredictionStatistics<true> final {
 WARNING_PUSH
 WARNING_DISABLE_UNREFERENCED_PARAMETER
    TML_INLINE void SetSumDenominator(FractionalDataType sumDenominator) {
+      UNUSED(sumDenominator);
       EBM_ASSERT(false); // this should never be called, but the compiler seems to want it to exist
    }
 WARNING_POP

--- a/src/core/ebmcore/PredictionStatistics.h
+++ b/src/core/ebmcore/PredictionStatistics.h
@@ -57,9 +57,12 @@ struct PredictionStatistics<true> final {
       EBM_ASSERT(false); // this should never be called, but the compiler seems to want it to exist
       return static_cast<FractionalDataType>(0);
    }
+WARNING_PUSH
+WARNING_DISABLE_UNREFERENCED_PARAMETER
    TML_INLINE void SetSumDenominator(FractionalDataType sumDenominator) {
       EBM_ASSERT(false); // this should never be called, but the compiler seems to want it to exist
    }
+WARNING_POP
    TML_INLINE void Add(const PredictionStatistics<true> & other) {
       sumResidualError += other.sumResidualError;
    }

--- a/src/core/ebmcore/PredictionStatistics.h
+++ b/src/core/ebmcore/PredictionStatistics.h
@@ -57,13 +57,10 @@ struct PredictionStatistics<true> final {
       EBM_ASSERT(false); // this should never be called, but the compiler seems to want it to exist
       return static_cast<FractionalDataType>(0);
    }
-WARNING_PUSH
-WARNING_DISABLE_UNREFERENCED_PARAMETER
    TML_INLINE void SetSumDenominator(FractionalDataType sumDenominator) {
       UNUSED(sumDenominator);
       EBM_ASSERT(false); // this should never be called, but the compiler seems to want it to exist
    }
-WARNING_POP
    TML_INLINE void Add(const PredictionStatistics<true> & other) {
       sumResidualError += other.sumResidualError;
    }

--- a/src/core/ebmcore/PredictionStatistics.h
+++ b/src/core/ebmcore/PredictionStatistics.h
@@ -55,7 +55,7 @@ struct PredictionStatistics<true> final {
 
    TML_INLINE FractionalDataType GetSumDenominator() const {
       EBM_ASSERT(false); // this should never be called, but the compiler seems to want it to exist
-      return static_cast<FractionalDataType>(0);
+      return FractionalDataType { 0 };
    }
    TML_INLINE void SetSumDenominator(FractionalDataType sumDenominator) {
       UNUSED(sumDenominator);

--- a/src/core/ebmcore/RandomStream.h
+++ b/src/core/ebmcore/RandomStream.h
@@ -17,7 +17,7 @@ class RandomStream final {
 
 public:
    TML_INLINE RandomStream(const IntegerDataType seed)
-      : m_randomGenerator((unsigned int)seed) /* initializing default_random_engine doesn't have official nothrow properties, but a random number generator should not have to throw */ {
+      : m_randomGenerator(static_cast<unsigned int>(seed)) /* initializing default_random_engine doesn't have official nothrow properties, but a random number generator should not have to throw */ {
       // TODO : change this to use the AES instruction set, which would ensure compatibility between languages and it would only take 2-3 clock cycles (although we'd still probably need to div [can we multiply instead] which is expensive).
    }
 

--- a/src/core/ebmcore/SamplingWithReplacement.cpp
+++ b/src/core/ebmcore/SamplingWithReplacement.cpp
@@ -57,7 +57,7 @@ SamplingWithReplacement * SamplingWithReplacement::GenerateSingleSamplingSet(Ran
 
    try {
       for(size_t iCase = 0; iCase < cCases; ++iCase) {
-         const size_t iCountOccurrences = pRandomStream->Next(static_cast<size_t>(0), cCases - 1);
+         const size_t iCountOccurrences = pRandomStream->Next(size_t { 0 }, cCases - 1);
          ++aCountOccurrences[iCountOccurrences];
       }
    } catch(...) {

--- a/src/core/ebmcore/SingleDimensionalTraining.h
+++ b/src/core/ebmcore/SingleDimensionalTraining.h
@@ -37,6 +37,7 @@ WARNING_PUSH
 WARNING_DISABLE_UNREFERENCED_PARAMETER
 template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * GetLeftTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
+   UNUSED(countBytesTreeNode);
    return pTreeNodeChildren;
 }
 WARNING_POP

--- a/src/core/ebmcore/SingleDimensionalTraining.h
+++ b/src/core/ebmcore/SingleDimensionalTraining.h
@@ -22,21 +22,24 @@ template<bool bRegression>
 class TreeNode;
 
 template<bool bRegression>
-TML_INLINE const size_t GetTreeNodeSizeOverflow(size_t cVectorLength) {
+TML_INLINE size_t GetTreeNodeSizeOverflow(size_t cVectorLength) {
    return IsMultiplyError(sizeof(PredictionStatistics<bRegression>), cVectorLength) ? true : IsAddError(sizeof(TreeNode<bRegression>) - sizeof(PredictionStatistics<bRegression>), sizeof(PredictionStatistics<bRegression>) * cVectorLength) ? true : false;
 }
 template<bool bRegression>
-TML_INLINE const size_t GetTreeNodeSize(size_t cVectorLength) {
+TML_INLINE size_t GetTreeNodeSize(size_t cVectorLength) {
    return sizeof(TreeNode<bRegression>) - sizeof(PredictionStatistics<bRegression>) + sizeof(PredictionStatistics<bRegression>) * cVectorLength;
 }
 template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * AddBytesTreeNode(TreeNode<bRegression> * pTreeNode, size_t countBytesAdd) {
    return reinterpret_cast<TreeNode<bRegression> *>(reinterpret_cast<char *>(pTreeNode) + countBytesAdd);
 }
+WARNING_PUSH
+WARNING_DISABLE_UNREFERENCED_PARAMETER
 template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * GetLeftTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
    return pTreeNodeChildren;
 }
+WARNING_POP
 template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * GetRightTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
    return AddBytesTreeNode<bRegression>(pTreeNodeChildren, countBytesTreeNode);

--- a/src/core/ebmcore/SingleDimensionalTraining.h
+++ b/src/core/ebmcore/SingleDimensionalTraining.h
@@ -529,16 +529,50 @@ retry_with_bigger_tree_node_children_array:
 
 // TODO : make variable ordering consistent with BinDataSet call below (put the attribute first since that's a definition that happens before the training data set)
 template<ptrdiff_t countCompilerClassificationTargetStates>
+bool TrainZeroDimensional(CachedTrainingThreadResources<IsRegression(countCompilerClassificationTargetStates)> * const pCachedThreadResources, const SamplingMethod * const pTrainingSet, SegmentedRegionCore<ActiveDataType, FractionalDataType> * const pSmallChangeToModelOverwriteSingleSamplingSet, const size_t cTargetStates) {
+   LOG(TraceLevelVerbose, "Entered TrainZeroDimensional");
+
+   const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
+   if(GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)) {
+      // TODO : move this to initialization where we execute it only once (it needs to be in the attribute combination loop though)
+      LOG(TraceLevelWarning, "WARNING TODO fill this in");
+      return true;
+   }
+   const size_t cBytesPerBinnedBucket = GetBinnedBucketSize<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength);
+   BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> * const pBinnedBucket = static_cast<BinnedBucket<IsRegression(countCompilerClassificationTargetStates)> *>(pCachedThreadResources->GetThreadByteBuffer1(cBytesPerBinnedBucket));
+   if(UNLIKELY(nullptr == pBinnedBucket)) {
+      LOG(TraceLevelWarning, "WARNING TrainZeroDimensional nullptr == pBinnedBucket");
+      return true;
+   }
+   memset(pBinnedBucket, 0, cBytesPerBinnedBucket);
+
+   BinDataSetTrainingZeroDimensions<countCompilerClassificationTargetStates>(pBinnedBucket, pTrainingSet, cTargetStates);
+
+   const PredictionStatistics<IsRegression(countCompilerClassificationTargetStates)> * const aSumPredictionStatistics = &pBinnedBucket->aPredictionStatistics[0];
+   if(IsRegression(countCompilerClassificationTargetStates)) {
+      FractionalDataType smallChangeToModel = ComputeSmallChangeInRegressionPredictionForOneSegment(aSumPredictionStatistics[0].sumResidualError, pBinnedBucket->cCasesInBucket);
+      FractionalDataType * pValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
+      pValues[0] = smallChangeToModel;
+   } else {
+      EBM_ASSERT(IsClassification(countCompilerClassificationTargetStates));
+      FractionalDataType * aValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
+      for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
+         FractionalDataType smallChangeToModel = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(aSumPredictionStatistics[iVector].sumResidualError, aSumPredictionStatistics[iVector].GetSumDenominator());
+         aValues[iVector] = smallChangeToModel;
+      }
+   }
+
+   LOG(TraceLevelVerbose, "Exited TrainZeroDimensional");
+   return false;
+}
+
+// TODO : make variable ordering consistent with BinDataSet call below (put the attribute first since that's a definition that happens before the training data set)
+template<ptrdiff_t countCompilerClassificationTargetStates>
 bool TrainSingleDimensional(CachedTrainingThreadResources<IsRegression(countCompilerClassificationTargetStates)> * const pCachedThreadResources, const SamplingMethod * const pTrainingSet, const AttributeCombinationCore * const pAttributeCombination, const size_t cTreeSplitsMax, const size_t cCasesRequiredForSplitParentMin, SegmentedRegionCore<ActiveDataType, FractionalDataType> * const pSmallChangeToModelOverwriteSingleSamplingSet, const size_t cTargetStates) {
    LOG(TraceLevelVerbose, "Entered TrainSingleDimensional");
 
-   size_t cTotalBuckets = 1;
-   for(size_t iDimension = 0; iDimension < pAttributeCombination->m_cAttributes; ++iDimension) {
-      const size_t cStates = pAttributeCombination->m_AttributeCombinationEntry[iDimension].m_pAttribute->m_cStates;
-      EBM_ASSERT(1 <= cStates); // this function can handle 1 == cStates even though that's a degenerate case that shouldn't be trained on (dimensions with 1 state don't contribute anything since they always have the same value)
-      EBM_ASSERT(!IsMultiplyError(cTotalBuckets, cStates)); // we check for simple multiplication overflow from m_cStates in TmlTrainingState->Initialize when we unpack attributeCombinationIndexes
-      cTotalBuckets *= cStates;
-   }
+   EBM_ASSERT(1 == pAttributeCombination->m_cAttributes);
+   size_t cTotalBuckets = pAttributeCombination->m_AttributeCombinationEntry[0].m_pAttribute->m_cStates;
 
    const size_t cVectorLength = GET_VECTOR_LENGTH(countCompilerClassificationTargetStates, cTargetStates);
    if(GetBinnedBucketSizeOverflow<IsRegression(countCompilerClassificationTargetStates)>(cVectorLength)) {

--- a/src/core/ebmcore/SingleDimensionalTraining.h
+++ b/src/core/ebmcore/SingleDimensionalTraining.h
@@ -22,23 +22,23 @@ template<bool bRegression>
 class TreeNode;
 
 template<bool bRegression>
-constexpr TML_INLINE const size_t GetTreeNodeSizeOverflow(size_t cVectorLength) {
+TML_INLINE const size_t GetTreeNodeSizeOverflow(size_t cVectorLength) {
    return IsMultiplyError(sizeof(PredictionStatistics<bRegression>), cVectorLength) ? true : IsAddError(sizeof(TreeNode<bRegression>) - sizeof(PredictionStatistics<bRegression>), sizeof(PredictionStatistics<bRegression>) * cVectorLength) ? true : false;
 }
 template<bool bRegression>
-constexpr TML_INLINE const size_t GetTreeNodeSize(size_t cVectorLength) {
+TML_INLINE const size_t GetTreeNodeSize(size_t cVectorLength) {
    return sizeof(TreeNode<bRegression>) - sizeof(PredictionStatistics<bRegression>) + sizeof(PredictionStatistics<bRegression>) * cVectorLength;
 }
 template<bool bRegression>
-constexpr TML_INLINE TreeNode<bRegression> * AddBytesTreeNode(TreeNode<bRegression> * pTreeNode, size_t countBytesAdd) {
+TML_INLINE TreeNode<bRegression> * AddBytesTreeNode(TreeNode<bRegression> * pTreeNode, size_t countBytesAdd) {
    return reinterpret_cast<TreeNode<bRegression> *>(reinterpret_cast<char *>(pTreeNode) + countBytesAdd);
 }
 template<bool bRegression>
-constexpr TML_INLINE TreeNode<bRegression> * GetLeftTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
+TML_INLINE TreeNode<bRegression> * GetLeftTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
    return pTreeNodeChildren;
 }
 template<bool bRegression>
-constexpr TML_INLINE TreeNode<bRegression> * GetRightTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
+TML_INLINE TreeNode<bRegression> * GetRightTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
    return AddBytesTreeNode<bRegression>(pTreeNodeChildren, countBytesTreeNode);
 }
 

--- a/src/core/ebmcore/SingleDimensionalTraining.h
+++ b/src/core/ebmcore/SingleDimensionalTraining.h
@@ -33,14 +33,11 @@ template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * AddBytesTreeNode(TreeNode<bRegression> * pTreeNode, size_t countBytesAdd) {
    return reinterpret_cast<TreeNode<bRegression> *>(reinterpret_cast<char *>(pTreeNode) + countBytesAdd);
 }
-WARNING_PUSH
-WARNING_DISABLE_UNREFERENCED_PARAMETER
 template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * GetLeftTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
    UNUSED(countBytesTreeNode);
    return pTreeNodeChildren;
 }
-WARNING_POP
 template<bool bRegression>
 TML_INLINE TreeNode<bRegression> * GetRightTreeNodeChild(TreeNode<bRegression> * pTreeNodeChildren, size_t countBytesTreeNode) {
    return AddBytesTreeNode<bRegression>(pTreeNodeChildren, countBytesTreeNode);

--- a/src/core/ebmcore/SingleDimensionalTraining.h
+++ b/src/core/ebmcore/SingleDimensionalTraining.h
@@ -177,7 +177,7 @@ public:
          const FractionalDataType sumResidualError1 = pBinnedBucketEntryCur->aPredictionStatistics[iVector].sumResidualError;
          const FractionalDataType sumResidualError2 = this->aPredictionStatistics[iVector].sumResidualError - sumResidualError1;
 
-         BEST_nodeSplittingScoreChildren += ComputeNodeSplittingScore(sumResidualError1, cCases1) + ComputeNodeSplittingScore(sumResidualError2, cCases2);
+         BEST_nodeSplittingScoreChildren += EbmStatistics::ComputeNodeSplittingScore(sumResidualError1, cCases1) + EbmStatistics::ComputeNodeSplittingScore(sumResidualError2, cCases2);
 
          aSumPredictionStatistics1[iVector].sumResidualError = sumResidualError1;
          aSumPredictionStatisticsBest[iVector].sumResidualError = sumResidualError1;
@@ -213,7 +213,7 @@ public:
             aSumResidualErrors2[iVector] = sumResidualError2;
 
             // TODO : we can make this faster by doing the division in ComputeNodeSplittingScore after we add all the numerators
-            const FractionalDataType nodeSplittingScoreChildrenOneVector = ComputeNodeSplittingScore(sumResidualError1, cCases1) + ComputeNodeSplittingScore(sumResidualError2, cCases2);
+            const FractionalDataType nodeSplittingScoreChildrenOneVector = EbmStatistics::ComputeNodeSplittingScore(sumResidualError1, cCases1) + EbmStatistics::ComputeNodeSplittingScore(sumResidualError2, cCases2);
             EBM_ASSERT(0 <= nodeSplittingScoreChildren);
             nodeSplittingScoreChildren += nodeSplittingScoreChildrenOneVector;
          }
@@ -256,7 +256,7 @@ public:
       FractionalDataType nodeSplittingScoreParent = 0;
       for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
          const FractionalDataType sumResidualErrorParent = this->aPredictionStatistics[iVector].sumResidualError;
-         nodeSplittingScoreParent += ComputeNodeSplittingScore(sumResidualErrorParent, cCasesParent);
+         nodeSplittingScoreParent += EbmStatistics::ComputeNodeSplittingScore(sumResidualErrorParent, cCasesParent);
       }
 
       // IMPORTANT!! : we need to finish all our calls that use this->m_UNION.beforeSplit BEFORE setting anything in m_UNION.afterSplit as we do below this comment!  The call above to this->GetCases() needs to be done above these lines because it uses m_UNION.beforeSplit for classification!
@@ -291,9 +291,9 @@ public:
          do {
             FractionalDataType smallChangeToModel;
             if(bRegression) {
-               smallChangeToModel = ComputeSmallChangeInRegressionPredictionForOneSegment(pPredictionStatistics->sumResidualError, this->GetCases());
+               smallChangeToModel = EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pPredictionStatistics->sumResidualError, this->GetCases());
             } else {
-               smallChangeToModel = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pPredictionStatistics->sumResidualError, pPredictionStatistics->GetSumDenominator());
+               smallChangeToModel = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pPredictionStatistics->sumResidualError, pPredictionStatistics->GetSumDenominator());
             }
             *pValuesCur = smallChangeToModel;
 
@@ -330,14 +330,14 @@ bool GrowDecisionTree(CachedTrainingThreadResources<IsRegression(countCompilerCl
       // we don't need to call EnsureValueCapacity because by default we start with a value capacity of 2 * cVectorLength
 
       if(IsRegression(countCompilerClassificationTargetStates)) {
-         FractionalDataType smallChangeToModel = ComputeSmallChangeInRegressionPredictionForOneSegment(aSumPredictionStatistics[0].sumResidualError, cCasesTotal);
+         FractionalDataType smallChangeToModel = EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(aSumPredictionStatistics[0].sumResidualError, cCasesTotal);
          FractionalDataType * pValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
          pValues[0] = smallChangeToModel;
       } else {
          EBM_ASSERT(IsClassification(countCompilerClassificationTargetStates));
          FractionalDataType * aValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
          for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
-            FractionalDataType smallChangeToModel = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(aSumPredictionStatistics[iVector].sumResidualError, aSumPredictionStatistics[iVector].GetSumDenominator());
+            FractionalDataType smallChangeToModel = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(aSumPredictionStatistics[iVector].sumResidualError, aSumPredictionStatistics[iVector].GetSumDenominator());
             aValues[iVector] = smallChangeToModel;
          }
       }
@@ -398,13 +398,13 @@ retry_with_bigger_tree_node_children_array:
 
       FractionalDataType * const aValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
       if(IsRegression(countCompilerClassificationTargetStates)) {
-         aValues[0] = ComputeSmallChangeInRegressionPredictionForOneSegment(pLeftChild->aPredictionStatistics[0].sumResidualError, pLeftChild->GetCases());
-         aValues[1] = ComputeSmallChangeInRegressionPredictionForOneSegment(pRightChild->aPredictionStatistics[0].sumResidualError, pRightChild->GetCases());
+         aValues[0] = EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pLeftChild->aPredictionStatistics[0].sumResidualError, pLeftChild->GetCases());
+         aValues[1] = EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(pRightChild->aPredictionStatistics[0].sumResidualError, pRightChild->GetCases());
       } else {
          EBM_ASSERT(IsClassification(countCompilerClassificationTargetStates));
          for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
-            aValues[iVector] = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pLeftChild->aPredictionStatistics[iVector].sumResidualError, pLeftChild->aPredictionStatistics[iVector].GetSumDenominator());
-            aValues[cVectorLength + iVector] = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pRightChild->aPredictionStatistics[iVector].sumResidualError, pRightChild->aPredictionStatistics[iVector].GetSumDenominator());
+            aValues[iVector] = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pLeftChild->aPredictionStatistics[iVector].sumResidualError, pLeftChild->aPredictionStatistics[iVector].GetSumDenominator());
+            aValues[cVectorLength + iVector] = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(pRightChild->aPredictionStatistics[iVector].sumResidualError, pRightChild->aPredictionStatistics[iVector].GetSumDenominator());
          }
       }
 
@@ -550,14 +550,14 @@ bool TrainZeroDimensional(CachedTrainingThreadResources<IsRegression(countCompil
 
    const PredictionStatistics<IsRegression(countCompilerClassificationTargetStates)> * const aSumPredictionStatistics = &pBinnedBucket->aPredictionStatistics[0];
    if(IsRegression(countCompilerClassificationTargetStates)) {
-      FractionalDataType smallChangeToModel = ComputeSmallChangeInRegressionPredictionForOneSegment(aSumPredictionStatistics[0].sumResidualError, pBinnedBucket->cCasesInBucket);
+      FractionalDataType smallChangeToModel = EbmStatistics::ComputeSmallChangeInRegressionPredictionForOneSegment(aSumPredictionStatistics[0].sumResidualError, pBinnedBucket->cCasesInBucket);
       FractionalDataType * pValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
       pValues[0] = smallChangeToModel;
    } else {
       EBM_ASSERT(IsClassification(countCompilerClassificationTargetStates));
       FractionalDataType * aValues = pSmallChangeToModelOverwriteSingleSamplingSet->GetValuePointer();
       for(size_t iVector = 0; iVector < cVectorLength; ++iVector) {
-         FractionalDataType smallChangeToModel = ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(aSumPredictionStatistics[iVector].sumResidualError, aSumPredictionStatistics[iVector].GetSumDenominator());
+         FractionalDataType smallChangeToModel = EbmStatistics::ComputeSmallChangeInClassificationLogOddPredictionForOneSegment(aSumPredictionStatistics[iVector].sumResidualError, aSumPredictionStatistics[iVector].GetSumDenominator());
          aValues[iVector] = smallChangeToModel;
       }
    }

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -333,7 +333,7 @@ static void TrainingSetInputAttributeLoop(const AttributeCombinationCore * const
       TrainingSetTargetAttributeLoop<cInputBits, 8, countCompilerClassificationTargetStates>(pAttributeCombination, pTrainingSet, pSmallChangeToModel, cTargetStates);
    } else if(cTargetStates <= 1 << 16) {
       TrainingSetTargetAttributeLoop<cInputBits, 16, countCompilerClassificationTargetStates>(pAttributeCombination, pTrainingSet, pSmallChangeToModel, cTargetStates);
-   } else if(cTargetStates <= static_cast<uint64_t>(1) << 32) {
+   } else if(static_cast<uint64_t>(cTargetStates) <= uint64_t { 1 } << 32) {
       // if this is a 32 bit system, then m_cStates can't be 0x100000000 or above, because we would have checked that when converting the 64 bit numbers into size_t, and m_cStates will be promoted to a 64 bit number for the above comparison
       // if this is a 64 bit system, then this comparison is fine
 
@@ -564,7 +564,7 @@ static FractionalDataType ValidationSetInputAttributeLoop(const AttributeCombina
       return ValidationSetTargetAttributeLoop<cInputBits, 8, countCompilerClassificationTargetStates>(pAttributeCombination, pValidationSet, pSmallChangeToModel, cTargetStates);
    } else if(cTargetStates <= 1 << 16) {
       return ValidationSetTargetAttributeLoop<cInputBits, 16, countCompilerClassificationTargetStates>(pAttributeCombination, pValidationSet, pSmallChangeToModel, cTargetStates);
-   } else if(cTargetStates <= static_cast<uint64_t>(1) << 32) {
+   } else if(static_cast<uint64_t>(cTargetStates) <= uint64_t { 1 } << 32) {
       // if this is a 32 bit system, then m_cStates can't be 0x100000000 or above, because we would have checked that when converting the 64 bit numbers into size_t, and m_cStates will be promoted to a 64 bit number for the above comparison
       // if this is a 64 bit system, then this comparison is fine
 

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -1143,12 +1143,9 @@ TML_INLINE CachedTrainingThreadResources<true> * GetCachedThreadResources<true>(
    return &pTmlState->m_cachedThreadResourcesUnion.regression;
 }
 
-// TODO remove this after we use aTrainingWeights and aValidationWeights into the TrainingStepPerTargetStates function
-WARNING_PUSH
-WARNING_DISABLE_UNREFERENCED_PARAMETER
-
 template<ptrdiff_t countCompilerClassificationTargetStates>
 static IntegerDataType TrainingStepPerTargetStates(TmlState * const pTmlState, const size_t iAttributeCombination, const FractionalDataType learningRate, const size_t cTreeSplitsMax, const size_t cCasesRequiredForSplitParentMin, const FractionalDataType * const aTrainingWeights, const FractionalDataType * const aValidationWeights, FractionalDataType * const pValidationMetricReturn) {
+   // TODO remove this after we use aTrainingWeights and aValidationWeights into the TrainingStepPerTargetStates function
    UNUSED(aTrainingWeights);
    UNUSED(aValidationWeights);
 
@@ -1190,8 +1187,6 @@ static IntegerDataType TrainingStepPerTargetStates(TmlState * const pTmlState, c
    return 0;
 }
 
-WARNING_POP
-
 template<ptrdiff_t iPossibleCompilerOptimizedTargetStates>
 TML_INLINE IntegerDataType CompilerRecursiveTrainingStep(const size_t cRuntimeTargetStates, TmlState * const pTmlState, const size_t iAttributeCombination, const FractionalDataType learningRate, const size_t cTreeSplitsMax, const size_t cCasesRequiredForSplitParentMin, const FractionalDataType * const aTrainingWeights, const FractionalDataType * const aValidationWeights, FractionalDataType * const pValidationMetricReturn) {
    EBM_ASSERT(IsClassification(iPossibleCompilerOptimizedTargetStates));
@@ -1203,9 +1198,6 @@ TML_INLINE IntegerDataType CompilerRecursiveTrainingStep(const size_t cRuntimeTa
    }
 }
 
-WARNING_PUSH
-WARNING_DISABLE_UNREFERENCED_PARAMETER
-
 template<>
 TML_INLINE IntegerDataType CompilerRecursiveTrainingStep<k_cCompilerOptimizedTargetStatesMax + 1>(const size_t cRuntimeTargetStates, TmlState * const pTmlState, const size_t iAttributeCombination, const FractionalDataType learningRate, const size_t cTreeSplitsMax, const size_t cCasesRequiredForSplitParentMin, const FractionalDataType * const aTrainingWeights, const FractionalDataType * const aValidationWeights, FractionalDataType * const pValidationMetricReturn) {
    UNUSED(cRuntimeTargetStates);
@@ -1213,8 +1205,6 @@ TML_INLINE IntegerDataType CompilerRecursiveTrainingStep<k_cCompilerOptimizedTar
    EBM_ASSERT(k_cCompilerOptimizedTargetStatesMax < cRuntimeTargetStates || 1 == cRuntimeTargetStates);
    return TrainingStepPerTargetStates<k_DynamicClassification>(pTmlState, iAttributeCombination, learningRate, cTreeSplitsMax, cCasesRequiredForSplitParentMin, aTrainingWeights, aValidationWeights, pValidationMetricReturn);
 }
-
-WARNING_POP
 
 // we made this a global because if we had put this variable inside the EbmTrainingState object, then we would need to dereference that before getting the count.  By making this global we can send a log message incase a bad EbmTrainingState object is sent into us
 // we only decrease the count if the count is non-zero, so at worst if there is a race condition then we'll output this log message more times than desired, but we can live with that

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -788,34 +788,34 @@ public:
    bool Initialize(const IntegerDataType randomSeed, const EbmAttribute * const aAttributes, const EbmAttributeCombination * const aAttributeCombinations, const IntegerDataType * attributeCombinationIndexes, const size_t cTrainingCases, const void * const aTrainingTargets, const IntegerDataType * const aTrainingData, const FractionalDataType * const aTrainingPredictionScores, const size_t cValidationCases, const void * const aValidationTargets, const IntegerDataType * const aValidationData, const FractionalDataType * const aValidationPredictionScores) {
       LOG(TraceLevelInfo, "Entered EbmTrainingState::Initialize");
       try {
-         if (m_bRegression) {
-            if (m_cachedThreadResourcesUnion.regression.IsError()) {
+         if(m_bRegression) {
+            if(m_cachedThreadResourcesUnion.regression.IsError()) {
                LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize m_cachedThreadResourcesUnion.regression.IsError()");
                return true;
             }
          } else {
-            if (m_cachedThreadResourcesUnion.classification.IsError()) {
+            if(m_cachedThreadResourcesUnion.classification.IsError()) {
                LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize m_cachedThreadResourcesUnion.classification.IsError()");
                return true;
             }
          }
 
-         if (nullptr == m_aAttributes) {
+         if(nullptr == m_aAttributes) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_aAttributes");
             return true;
          }
 
-         if (UNLIKELY(nullptr == m_apAttributeCombinations)) {
+         if(UNLIKELY(nullptr == m_apAttributeCombinations)) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_apAttributeCombinations");
             return true;
          }
 
-         if (UNLIKELY(nullptr == m_pSmallChangeToModelOverwriteSingleSamplingSet)) {
+         if(UNLIKELY(nullptr == m_pSmallChangeToModelOverwriteSingleSamplingSet)) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_pSmallChangeToModelOverwriteSingleSamplingSet");
             return true;
          }
 
-         if (UNLIKELY(nullptr == m_pSmallChangeToModelAccumulatedFromSamplingSets)) {
+         if(UNLIKELY(nullptr == m_pSmallChangeToModelAccumulatedFromSamplingSets)) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_pSmallChangeToModelAccumulatedFromSamplingSets");
             return true;
          }
@@ -834,7 +834,7 @@ public:
 
             IntegerDataType countStates = pAttributeInitialize->countStates;
             EBM_ASSERT(1 <= countStates); // we can handle 1 == cStates even though that's a degenerate case that shouldn't be trained on (dimensions with 1 state don't contribute anything since they always have the same value)
-            if (!IsNumberConvertable<size_t, IntegerDataType>(countStates)) {
+            if(!IsNumberConvertable<size_t, IntegerDataType>(countStates)) {
                LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize !IsNumberConvertable<size_t, IntegerDataType>(countStates)");
                return true;
             }
@@ -855,19 +855,19 @@ public:
 
             ++iAttributeInitialize;
             ++pAttributeInitialize;
-         } while (pAttributeEnd != pAttributeInitialize);
+         } while(pAttributeEnd != pAttributeInitialize);
          LOG(TraceLevelInfo, "EbmTrainingState::Initialize done attribute processing");
 
          size_t cVectorLength = GetVectorLengthFlatCore(m_cTargetStates);
 
          LOG(TraceLevelInfo, "EbmTrainingState::Initialize starting attribute combination processing");
          const IntegerDataType * pAttributeCombinationIndex = attributeCombinationIndexes;
-         for (size_t iAttributeCombination = 0; iAttributeCombination < m_cAttributeCombinations; ++iAttributeCombination) {
+         for(size_t iAttributeCombination = 0; iAttributeCombination < m_cAttributeCombinations; ++iAttributeCombination) {
             const EbmAttributeCombination * const pAttributeCombinationInterop = &aAttributeCombinations[iAttributeCombination];
 
             IntegerDataType countAttributesInCombination = pAttributeCombinationInterop->countAttributesInCombination;
             EBM_ASSERT(0 <= countAttributesInCombination);
-            if (!IsNumberConvertable<size_t, IntegerDataType>(countAttributesInCombination)) {
+            if(!IsNumberConvertable<size_t, IntegerDataType>(countAttributesInCombination)) {
                LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize !IsNumberConvertable<size_t, IntegerDataType>(countAttributesInCombination)");
                return true;
             }
@@ -947,7 +947,7 @@ public:
 
          LOG(TraceLevelInfo, "Entered DataSetAttributeCombination for m_pTrainingSet");
          m_pTrainingSet = new (std::nothrow) DataSetAttributeCombination(true, !m_bRegression, !m_bRegression, m_cAttributeCombinations, m_apAttributeCombinations, cTrainingCases, aTrainingData, aTrainingTargets, aTrainingPredictionScores, cVectorLength);
-         if (nullptr == m_pTrainingSet || m_pTrainingSet->IsError()) {
+         if(nullptr == m_pTrainingSet || m_pTrainingSet->IsError()) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_pTrainingSet || m_pTrainingSet->IsError()");
             return true;
          }
@@ -955,7 +955,7 @@ public:
 
          LOG(TraceLevelInfo, "Entered DataSetAttributeCombination for m_pValidationSet");
          m_pValidationSet = new (std::nothrow) DataSetAttributeCombination(m_bRegression, !m_bRegression, !m_bRegression, m_cAttributeCombinations, m_apAttributeCombinations, cValidationCases, aValidationData, aValidationTargets, aValidationPredictionScores, cVectorLength);
-         if (nullptr == m_pValidationSet || m_pValidationSet->IsError()) {
+         if(nullptr == m_pValidationSet || m_pValidationSet->IsError()) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_pValidationSet || m_pValidationSet->IsError()");
             return true;
          }
@@ -965,29 +965,29 @@ public:
 
          EBM_ASSERT(nullptr == m_apSamplingSets);
          m_apSamplingSets = SamplingWithReplacement::GenerateSamplingSets(&randomStream, m_pTrainingSet, m_cSamplingSets);
-         if (UNLIKELY(nullptr == m_apSamplingSets)) {
+         if(UNLIKELY(nullptr == m_apSamplingSets)) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_apSamplingSets");
             return true;
          }
 
          EBM_ASSERT(nullptr == m_apCurrentModel);
          m_apCurrentModel = InitializeSegmentsCore(m_cAttributeCombinations, m_apAttributeCombinations, cVectorLength);
-         if (nullptr == m_apCurrentModel) {
+         if(nullptr == m_apCurrentModel) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_apCurrentModel");
             return true;
          }
          EBM_ASSERT(nullptr == m_apBestModel);
          m_apBestModel = InitializeSegmentsCore(m_cAttributeCombinations, m_apAttributeCombinations, cVectorLength);
-         if (nullptr == m_apBestModel) {
+         if(nullptr == m_apBestModel) {
             LOG(TraceLevelWarning, "WARNING EbmTrainingState::Initialize nullptr == m_apBestModel");
             return true;
          }
 
-         if (m_bRegression) {
+         if(m_bRegression) {
             InitializeResiduals<k_Regression>(cTrainingCases, aTrainingTargets, aTrainingPredictionScores, m_pTrainingSet->GetResidualPointer(), 0);
             InitializeResiduals<k_Regression>(cValidationCases, aValidationTargets, aValidationPredictionScores, m_pValidationSet->GetResidualPointer(), 0);
          } else {
-            if (2 == m_cTargetStates) {
+            if(2 == m_cTargetStates) {
                InitializeResiduals<2>(cTrainingCases, aTrainingTargets, aTrainingPredictionScores, m_pTrainingSet->GetResidualPointer(), m_cTargetStates);
             } else {
                InitializeResiduals<k_DynamicClassification>(cTrainingCases, aTrainingTargets, aTrainingPredictionScores, m_pTrainingSet->GetResidualPointer(), m_cTargetStates);
@@ -1055,27 +1055,27 @@ TmlState * AllocateCore(bool bRegression, IntegerDataType randomSeed, IntegerDat
    // validationPredictionScores can be null
    EBM_ASSERT(0 <= countInnerBags); // 0 means use the full set (good value).  1 means make a single bag (this is useless but allowed for comparison purposes).  2+ are good numbers of bag
 
-   if (!IsNumberConvertable<size_t, IntegerDataType>(countAttributes)) {
+   if(!IsNumberConvertable<size_t, IntegerDataType>(countAttributes)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore !IsNumberConvertable<size_t, IntegerDataType>(countAttributes)");
       return nullptr;
    }
-   if (!IsNumberConvertable<size_t, IntegerDataType>(countAttributeCombinations)) {
+   if(!IsNumberConvertable<size_t, IntegerDataType>(countAttributeCombinations)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore !IsNumberConvertable<size_t, IntegerDataType>(countAttributeCombinations)");
       return nullptr;
    }
-   if (!IsNumberConvertable<size_t, IntegerDataType>(countTargetStates)) {
+   if(!IsNumberConvertable<size_t, IntegerDataType>(countTargetStates)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore !IsNumberConvertable<size_t, IntegerDataType>(countTargetStates)");
       return nullptr;
    }
-   if (!IsNumberConvertable<size_t, IntegerDataType>(countTrainingCases)) {
+   if(!IsNumberConvertable<size_t, IntegerDataType>(countTrainingCases)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore !IsNumberConvertable<size_t, IntegerDataType>(countTrainingCases)");
       return nullptr;
    }
-   if (!IsNumberConvertable<size_t, IntegerDataType>(countValidationCases)) {
+   if(!IsNumberConvertable<size_t, IntegerDataType>(countValidationCases)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore !IsNumberConvertable<size_t, IntegerDataType>(countValidationCases)");
       return nullptr;
    }
-   if (!IsNumberConvertable<size_t, IntegerDataType>(countInnerBags)) {
+   if(!IsNumberConvertable<size_t, IntegerDataType>(countInnerBags)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore !IsNumberConvertable<size_t, IntegerDataType>(countInnerBags)");
       return nullptr;
    }
@@ -1089,11 +1089,11 @@ TmlState * AllocateCore(bool bRegression, IntegerDataType randomSeed, IntegerDat
 
    size_t cVectorLength = GetVectorLengthFlatCore(cTargetStates);
 
-   if (IsMultiplyError(cVectorLength, cTrainingCases)) {
+   if(IsMultiplyError(cVectorLength, cTrainingCases)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore IsMultiplyError(cVectorLength, cTrainingCases)");
       return nullptr;
    }
-   if (IsMultiplyError(cVectorLength, cValidationCases)) {
+   if(IsMultiplyError(cVectorLength, cValidationCases)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore IsMultiplyError(cVectorLength, cValidationCases)");
       return nullptr;
    }
@@ -1106,11 +1106,11 @@ TmlState * AllocateCore(bool bRegression, IntegerDataType randomSeed, IntegerDat
    LOG(TraceLevelInfo, "Entered EbmTrainingState");
    TmlState * const pTmlState = new (std::nothrow) TmlState(bRegression, cTargetStates, cAttributes, cAttributeCombinations, cInnerBags);
    LOG(TraceLevelInfo, "Exited EbmTrainingState %p", static_cast<void *>(pTmlState));
-   if (UNLIKELY(nullptr == pTmlState)) {
+   if(UNLIKELY(nullptr == pTmlState)) {
       LOG(TraceLevelWarning, "WARNING AllocateCore nullptr == pTmlState");
       return nullptr;
    }
-   if (UNLIKELY(pTmlState->Initialize(randomSeed, attributes, attributeCombinations, attributeCombinationIndexes, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores))) {
+   if(UNLIKELY(pTmlState->Initialize(randomSeed, attributes, attributeCombinations, attributeCombinationIndexes, cTrainingCases, trainingTargets, trainingData, trainingPredictionScores, cValidationCases, validationTargets, validationData, validationPredictionScores))) {
       LOG(TraceLevelWarning, "WARNING AllocateCore pTmlState->Initialize");
       delete pTmlState;
       return nullptr;

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -178,7 +178,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
                constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
                if(bZeroingResiduals) {
-                  pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLength)] = 0;
+                  pResidualError[k_iZeroResidual - static_cast<ptrdiff_t>(cVectorLength)] = 0;
                }
             }
             pTrainingPredictionScores += cVectorLength;
@@ -293,7 +293,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
                constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
                if(bZeroingResiduals) {
-                  pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLength)] = 0;
+                  pResidualError[k_iZeroResidual - static_cast<ptrdiff_t>(cVectorLength)] = 0;
                }
             }
             pTrainingPredictionScores += cVectorLength;

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -123,7 +123,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
          const FractionalDataType smallChangeToPrediction = pValues[0];
          while(pResidualErrorEnd != pResidualError) {
             // this will apply a small fix to our existing TrainingPredictionScores, either positive or negative, whichever is needed
-            const FractionalDataType residualError = ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
+            const FractionalDataType residualError = EbmStatistics::ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
             *pResidualError = residualError;
             ++pResidualError;
          }
@@ -142,7 +142,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                // this will apply a small fix to our existing TrainingPredictionScores, either positive or negative, whichever is needed
                const FractionalDataType trainingPredictionScore = *pTrainingPredictionScores + smallChangeToPredictionScores;
                *pTrainingPredictionScores = trainingPredictionScore;
-               const FractionalDataType residualError = ComputeClassificationResidualErrorBinaryclass(trainingPredictionScore, targetData);
+               const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorBinaryclass(trainingPredictionScore, targetData);
                *pResidualError = residualError;
                ++pResidualError;
             } else {
@@ -163,7 +163,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                StorageDataTypeCore iVector2 = 0;
                do {
                   // TODO : we're calculating exp(predictionScore) above, and then again in ComputeClassificationResidualErrorMulticlass.  exp(..) is expensive so we should just do it once instead and store the result in a small memory array here
-                  const FractionalDataType residualError = ComputeClassificationResidualErrorMulticlass(sumExp, pTrainingPredictionScores[iVector2], targetData, iVector2);
+                  const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorMulticlass(sumExp, pTrainingPredictionScores[iVector2], targetData, iVector2);
                   *pResidualError = residualError;
                   ++pResidualError;
                   ++iVector2;
@@ -213,7 +213,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
 
             const FractionalDataType smallChangeToPrediction = pValues[0];
             // this will apply a small fix to our existing TrainingPredictionScores, either positive or negative, whichever is needed
-            const FractionalDataType residualError = ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
+            const FractionalDataType residualError = EbmStatistics::ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
             *pResidualError = residualError;
             ++pResidualError;
 
@@ -258,7 +258,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                // this will apply a small fix to our existing TrainingPredictionScores, either positive or negative, whichever is needed
                const FractionalDataType trainingPredictionScore = *pTrainingPredictionScores + smallChangeToPredictionScores;
                *pTrainingPredictionScores = trainingPredictionScore;
-               const FractionalDataType residualError = ComputeClassificationResidualErrorBinaryclass(trainingPredictionScore, targetData);
+               const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorBinaryclass(trainingPredictionScore, targetData);
                *pResidualError = residualError;
                ++pResidualError;
             } else {
@@ -278,7 +278,7 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                StorageDataTypeCore iVector2 = 0;
                do {
                   // TODO : we're calculating exp(predictionScore) above, and then again in ComputeClassificationResidualErrorMulticlass.  exp(..) is expensive so we should just do it once instead and store the result in a small memory array here
-                  const FractionalDataType residualError = ComputeClassificationResidualErrorMulticlass(sumExp, pTrainingPredictionScores[iVector2], targetData, iVector2);
+                  const FractionalDataType residualError = EbmStatistics::ComputeClassificationResidualErrorMulticlass(sumExp, pTrainingPredictionScores[iVector2], targetData, iVector2);
                   *pResidualError = residualError;
                   ++pResidualError;
                   ++iVector2;
@@ -369,7 +369,7 @@ static FractionalDataType ValidationSetTargetAttributeLoop(const AttributeCombin
          FractionalDataType rootMeanSquareError = 0;
          while(pResidualErrorEnd != pResidualError) {
             // this will apply a small fix to our existing ValidationPredictionScores, either positive or negative, whichever is needed
-            const FractionalDataType residualError = ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
+            const FractionalDataType residualError = EbmStatistics::ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
             rootMeanSquareError += residualError * residualError;
             *pResidualError = residualError;
             ++pResidualError;
@@ -396,7 +396,7 @@ static FractionalDataType ValidationSetTargetAttributeLoop(const AttributeCombin
                // this will apply a small fix to our existing ValidationPredictionScores, either positive or negative, whichever is needed
                const FractionalDataType validationPredictionScores = *pValidationPredictionScores + smallChangeToPredictionScores;
                *pValidationPredictionScores = validationPredictionScores;
-               sumLogLoss += ComputeClassificationSingleCaseLogLossBinaryclass(validationPredictionScores, targetData);
+               sumLogLoss += EbmStatistics::ComputeClassificationSingleCaseLogLossBinaryclass(validationPredictionScores, targetData);
                ++pValidationPredictionScores;
             } else {
                FractionalDataType sumExp = 0;
@@ -415,7 +415,7 @@ static FractionalDataType ValidationSetTargetAttributeLoop(const AttributeCombin
                   ++iVector;
                } while(iVector < cVectorLength);
                // TODO: store the result of std::exp above for the index that we care about above since exp(..) is going to be expensive and probably even more expensive than an unconditional branch
-               sumLogLoss += ComputeClassificationSingleCaseLogLossMulticlass(sumExp, pValidationPredictionScores - cVectorLength, targetData);
+               sumLogLoss += EbmStatistics::ComputeClassificationSingleCaseLogLossMulticlass(sumExp, pValidationPredictionScores - cVectorLength, targetData);
             }
             ++pTargetData;
          }
@@ -451,7 +451,7 @@ static FractionalDataType ValidationSetTargetAttributeLoop(const AttributeCombin
 
             const FractionalDataType smallChangeToPrediction = pValues[0];
             // this will apply a small fix to our existing ValidationPredictionScores, either positive or negative, whichever is needed
-            const FractionalDataType residualError = ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
+            const FractionalDataType residualError = EbmStatistics::ComputeRegressionResidualError(*pResidualError - smallChangeToPrediction);
             rootMeanSquareError += residualError * residualError;
             *pResidualError = residualError;
             ++pResidualError;
@@ -504,7 +504,7 @@ static FractionalDataType ValidationSetTargetAttributeLoop(const AttributeCombin
                // this will apply a small fix to our existing ValidationPredictionScores, either positive or negative, whichever is needed
                const FractionalDataType validationPredictionScores = *pValidationPredictionScores + smallChangeToPredictionScores;
                *pValidationPredictionScores = validationPredictionScores;
-               sumLogLoss += ComputeClassificationSingleCaseLogLossBinaryclass(validationPredictionScores, targetData);
+               sumLogLoss += EbmStatistics::ComputeClassificationSingleCaseLogLossBinaryclass(validationPredictionScores, targetData);
                ++pValidationPredictionScores;
             } else {
                FractionalDataType sumExp = 0;
@@ -523,7 +523,7 @@ static FractionalDataType ValidationSetTargetAttributeLoop(const AttributeCombin
                   ++iVector;
                } while(iVector < cVectorLength);
                // TODO: store the result of std::exp above for the index that we care about above since exp(..) is going to be expensive and probably even more expensive than an unconditional branch
-               sumLogLoss += ComputeClassificationSingleCaseLogLossMulticlass(sumExp, pValidationPredictionScores - cVectorLength, targetData);
+               sumLogLoss += EbmStatistics::ComputeClassificationSingleCaseLogLossMulticlass(sumExp, pValidationPredictionScores - cVectorLength, targetData);
             }
             ++pTargetData;
 

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -209,7 +209,8 @@ static void TrainingSetTargetAttributeLoop(const AttributeCombinationCore * cons
                // insted of allowing them to be scaled.  
                // Probability = exp(T1 + I1) / [exp(T1 + I1) + exp(T2 + I2) + exp(T3 + I3)] => we can add a constant inside each exp(..) term, which will be multiplication outside the exp(..), which
                // means the numerator and denominator are multiplied by the same constant, which cancels eachother out.  We can thus set exp(T2 + I2) to exp(0) and adjust the other terms
-               if(0 <= k_iZeroResidual) {
+               constexpr bool bZeroingResiduals = 0 <= k_iZeroResidual;
+               if(bZeroingResiduals) {
                   pResidualError[static_cast<ptrdiff_t>(k_iZeroResidual) - static_cast<ptrdiff_t>(cVectorLength)] = 0;
                }
             }
@@ -482,7 +483,8 @@ static bool GenerateModelLoop(SegmentedRegionCore<ActiveDataType, FractionalData
       //   pSmallChangeToModelAccumulated->Multiply(learningRate / cSamplingSetsAfterZero);
       //}
 
-      if(bTreatBinaryAsMulticlass && 2 == countCompilerClassificationTargetStates) {
+      constexpr bool bDividing = bTreatBinaryAsMulticlass && 2 == countCompilerClassificationTargetStates;
+      if(bDividing) {
          pSmallChangeToModelAccumulated->Multiply(learningRate / cSamplingSetsAfterZero / 2);
       } else {
          pSmallChangeToModelAccumulated->Multiply(learningRate / cSamplingSetsAfterZero);

--- a/src/core/ebmcore/Training.cpp
+++ b/src/core/ebmcore/Training.cpp
@@ -1149,6 +1149,9 @@ WARNING_DISABLE_UNREFERENCED_PARAMETER
 
 template<ptrdiff_t countCompilerClassificationTargetStates>
 static IntegerDataType TrainingStepPerTargetStates(TmlState * const pTmlState, const size_t iAttributeCombination, const FractionalDataType learningRate, const size_t cTreeSplitsMax, const size_t cCasesRequiredForSplitParentMin, const FractionalDataType * const aTrainingWeights, const FractionalDataType * const aValidationWeights, FractionalDataType * const pValidationMetricReturn) {
+   UNUSED(aTrainingWeights);
+   UNUSED(aValidationWeights);
+
    LOG(TraceLevelVerbose, "Entered TrainingStepPerTargetStates");
 
    const size_t cSamplingSetsAfterZero = 0 == pTmlState->m_cSamplingSets ? 1 : pTmlState->m_cSamplingSets;
@@ -1205,6 +1208,7 @@ WARNING_DISABLE_UNREFERENCED_PARAMETER
 
 template<>
 TML_INLINE IntegerDataType CompilerRecursiveTrainingStep<k_cCompilerOptimizedTargetStatesMax + 1>(const size_t cRuntimeTargetStates, TmlState * const pTmlState, const size_t iAttributeCombination, const FractionalDataType learningRate, const size_t cTreeSplitsMax, const size_t cCasesRequiredForSplitParentMin, const FractionalDataType * const aTrainingWeights, const FractionalDataType * const aValidationWeights, FractionalDataType * const pValidationMetricReturn) {
+   UNUSED(cRuntimeTargetStates);
    // it is logically possible, but uninteresting to have a classification with 1 target state, so let our runtime system handle those unlikley and uninteresting cases
    EBM_ASSERT(k_cCompilerOptimizedTargetStatesMax < cRuntimeTargetStates || 1 == cRuntimeTargetStates);
    return TrainingStepPerTargetStates<k_DynamicClassification>(pTmlState, iAttributeCombination, learningRate, cTreeSplitsMax, cCasesRequiredForSplitParentMin, aTrainingWeights, aValidationWeights, pValidationMetricReturn);

--- a/src/core/ebmcore/ebmcore.vcxproj
+++ b/src/core/ebmcore/ebmcore.vcxproj
@@ -113,6 +113,7 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -156,6 +157,7 @@ EXIT /B 0
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -203,6 +205,7 @@ EXIT /B 0
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -252,6 +255,7 @@ EXIT /B 0
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/core/ebmcore/ebmcore.vcxproj
+++ b/src/core/ebmcore/ebmcore.vcxproj
@@ -113,7 +113,7 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
-      <TreatWarningAsError>false</TreatWarningAsError>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -157,7 +157,7 @@ EXIT /B 0
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
-      <TreatWarningAsError>false</TreatWarningAsError>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -205,7 +205,7 @@ EXIT /B 0
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
-      <TreatWarningAsError>false</TreatWarningAsError>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -255,7 +255,7 @@ EXIT /B 0
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <OpenMPSupport>false</OpenMPSupport>
-      <TreatWarningAsError>false</TreatWarningAsError>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/core/ebmcore/ebmcore.vcxproj
+++ b/src/core/ebmcore/ebmcore.vcxproj
@@ -106,6 +106,13 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\inc</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StringPooling>true</StringPooling>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -140,6 +147,14 @@ EXIT /B 0
       <AdditionalIncludeDirectories>$(ProjectDir)..\inc</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <OmitFramePointers>false</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -169,7 +184,7 @@ EXIT /B 0
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>EBMCORE_EXPORTS;_WINDOWS;_USRDLL;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
@@ -177,6 +192,15 @@ EXIT /B 0
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -208,7 +232,7 @@ EXIT /B 0
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>EBMCORE_EXPORTS;_WINDOWS;_USRDLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
@@ -216,6 +240,15 @@ EXIT /B 0
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/core/ebmcore/ebmcore.vcxproj
+++ b/src/core/ebmcore/ebmcore.vcxproj
@@ -119,6 +119,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>ebmcore.def</ModuleDefinitionFile>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" "$(ProjectDir)..\..\..\src\python\interpret\lib" "$(TargetName).dll" "$(TargetName).pdb"
@@ -161,6 +162,7 @@ EXIT /B 0
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>ebmcore.def</ModuleDefinitionFile>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" "$(ProjectDir)..\..\..\src\python\interpret\lib" "$(TargetName).dll" "$(TargetName).pdb"
@@ -209,6 +211,7 @@ EXIT /B 0
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>ebmcore.def</ModuleDefinitionFile>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" "$(ProjectDir)..\..\..\src\python\interpret\lib" "$(TargetName).dll" "$(TargetName).pdb"
@@ -257,6 +260,7 @@ EXIT /B 0
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>ebmcore.def</ModuleDefinitionFile>
+      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
     </Link>
     <PostBuildEvent>
       <Command>robocopy /R:2 /NP "$(ProjectDir)..\..\..\tmp\vs\bin\$(Configuration)\win\$(Platform)\$(MSBuildProjectName)" "$(ProjectDir)..\..\..\src\python\interpret\lib" "$(TargetName).dll" "$(TargetName).pdb"

--- a/src/core/inc/ebmcore.h
+++ b/src/core/inc/ebmcore.h
@@ -18,7 +18,7 @@ extern "C" {
 #define EBMCORE_IMPORT_EXPORT __attribute__ ((visibility ("default")))
 #define EBMCORE_CALLING_CONVENTION
 
-#elif defined(_MSC_VER) /* compiler type */
+#elif defined(_MSC_VER) // compiler type
 
 #ifdef EBMCORE_EXPORTS
 // we use a .def file in Visual Studio because we can remove the C name mangling entirely (in addition to C++ name mangling), unlike __declspec(dllexport)
@@ -37,9 +37,9 @@ extern "C" {
 #define EBMCORE_CALLING_CONVENTION __stdcall
 #endif // _WIN64
 
-#else // compiler
+#else // compiler type
 #error compiler not recognized
-#endif // compiler
+#endif // compiler type
 
 typedef struct {
    // this struct is to enforce that our caller doesn't mix EbmTraining and EbmInteraction pointers.  In C/C++ languages the caller will get an error if they try to mix these pointer types.

--- a/src/python/.gitignore
+++ b/src/python/.gitignore
@@ -11,6 +11,7 @@ docs/_build/
 lib/
 log.txt
 test-log.txt
+dev-log.txt
 *.csv
 *.ipynb
 .coverage.*

--- a/src/python/interpret/glassbox/ebm/ebm.py
+++ b/src/python/interpret/glassbox/ebm/ebm.py
@@ -987,7 +987,6 @@ class BaseEBM(BaseEstimator):
             upper_bound = max(upper_bound, np.max(scores + errors))
 
         bounds = (lower_bound, upper_bound)
-        print(bounds)
 
         # Add per feature graph
         data_dicts = []

--- a/src/python/interpret/glassbox/ebm/ebm.py
+++ b/src/python/interpret/glassbox/ebm/ebm.py
@@ -75,6 +75,7 @@ class EBMExplanation(FeatureValueExplanation):
                 title="Overall Importance:<br>Mean Absolute Score",
                 start_zero=True,
             )
+
             return figure
 
         # Continuous feature graph
@@ -84,7 +85,6 @@ class EBMExplanation(FeatureValueExplanation):
         ):
             title = self.feature_names[key]
             figure = plot_continuous_bar(data_dict, title=title)
-
 
             return figure
 

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -41,7 +41,7 @@ def test_show_selenium(explanations):
     mini_url = show_link(explanations[2])
 
     # Set up driver
-    timeout = 30
+    timeout = 60
     driver = webdriver.Firefox()
     driver.implicitly_wait(timeout)
 

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -41,15 +41,16 @@ def test_show_selenium(explanations):
     mini_url = show_link(explanations[2])
 
     # Set up driver
+    timeout = 30
     driver = webdriver.Firefox()
-    driver.implicitly_wait(30)
+    driver.implicitly_wait(timeout)
 
     # Home page
     driver.get(dashboard_url)
     driver.find_element_by_id("overview-tab")
 
     # Expect overview tab's welcome message
-    wait = WebDriverWait(driver, 10)
+    wait = WebDriverWait(driver, timeout)
     wait.until(
         EC.text_to_be_present_in_element(
             (By.ID, "overview-tab"), "Welcome to Interpret ML"

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -5,6 +5,25 @@ from ..perf import ROC
 from ..glassbox import LogisticRegression, ExplainableBoostingClassifier
 from ..visual.interactive import set_show_addr, shutdown_show_server, show_link
 
+# Timeout for element not show up in selenium driver.
+TIMEOUT = 60
+
+
+@pytest.fixture(scope="module")
+def driver():
+    from selenium import webdriver
+
+    _driver = webdriver.Firefox()
+
+    # Set up driver
+    _driver = webdriver.Firefox()
+    _driver.implicitly_wait(TIMEOUT)
+
+    yield _driver
+
+    # Close driver
+    _driver.close()
+
 
 @pytest.fixture(scope="module")
 def explanations():
@@ -29,8 +48,7 @@ def explanations():
 
 # TODO: Code duplication, refactor.
 @pytest.mark.selenium
-def test_show_selenium(explanations):
-    from selenium import webdriver
+def test_show_selenium(explanations, driver):
     from selenium.webdriver.support.ui import WebDriverWait
     from selenium.webdriver.support import expected_conditions as EC
     from selenium.webdriver.common.by import By
@@ -40,17 +58,12 @@ def test_show_selenium(explanations):
     dashboard_url = show_link(explanations)
     mini_url = show_link(explanations[2])
 
-    # Set up driver
-    timeout = 60
-    driver = webdriver.Firefox()
-    driver.implicitly_wait(timeout)
-
     # Home page
     driver.get(dashboard_url)
     driver.find_element_by_id("overview-tab")
 
     # Expect overview tab's welcome message
-    wait = WebDriverWait(driver, timeout)
+    wait = WebDriverWait(driver, TIMEOUT)
     wait.until(
         EC.text_to_be_present_in_element(
             (By.ID, "overview-tab"), "Welcome to Interpret ML"
@@ -286,8 +299,5 @@ def test_show_selenium(explanations):
     wait.until(EC.presence_of_element_located(
         (By.ID, "graph-0-0")
     ))
-
-    # Close driver
-    driver.close()
 
     shutdown_show_server()

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -53,6 +53,12 @@ def test_dashboard(explanations):
         )
     )
 
+    # Move to data
+    # tabs_el = driver.find_element_by_id("tabs")
+    # data_tab_el = tabs_el.find_element_by_xpath("//div[contains(text(),'Data')]")
+    # data_tab_el.click()
+
+    # Move to perf
     # Move to local
     # Move to global
 

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -14,21 +14,22 @@ def explanations():
     lr = LogisticRegression()
     lr.fit(data["train"]["X"], data["train"]["y"])
 
-    hist_exp = ClassHistogram().explain_data(data["train"]["X"], data["train"]["y"])
+    hist_exp = ClassHistogram().explain_data(data["train"]["X"], data["train"]["y"], name="Histogram")
 
-    lr_global_exp = lr.explain_global()
-    lr_local_exp = lr.explain_local(data["test"]["X"].head(), data["test"]["y"].head())
-    lr_perf = ROC(lr.predict_proba).explain_perf(data["test"]["X"], data["test"]["y"])
+    lr_global_exp = lr.explain_global(name="LR")
+    lr_local_exp = lr.explain_local(data["test"]["X"].head(), data["test"]["y"].head(), name="LR")
+    lr_perf = ROC(lr.predict_proba).explain_perf(data["test"]["X"], data["test"]["y"], name="LR")
 
-    ebm_global_exp = ebm.explain_global()
-    ebm_local_exp = ebm.explain_local(data["test"]["X"], data["test"]["y"])
-    ebm_perf = ROC(ebm.predict_proba).explain_perf(data["test"]["X"], data["test"]["y"])
+    ebm_global_exp = ebm.explain_global(name="EBM")
+    ebm_local_exp = ebm.explain_local(data["test"]["X"].head(), data["test"]["y"].head(), name="EBM")
+    ebm_perf = ROC(ebm.predict_proba).explain_perf(data["test"]["X"], data["test"]["y"], name="EBM")
 
     return [hist_exp, lr_local_exp, lr_global_exp, lr_perf, ebm_local_exp, ebm_global_exp, ebm_perf]
 
 
+# TODO: Code duplication, refactor.
 @pytest.mark.selenium
-def test_dashboard(explanations):
+def test_show_selenium(explanations):
     from selenium import webdriver
     from selenium.webdriver.support.ui import WebDriverWait
     from selenium.webdriver.support import expected_conditions as EC
@@ -36,16 +37,18 @@ def test_dashboard(explanations):
 
     target_addr = ("127.0.0.1", 7100)
     set_show_addr(target_addr)
-    url = show_link(explanations)
+    dashboard_url = show_link(explanations)
+    mini_url = show_link(explanations[2])
 
     # Set up driver
     driver = webdriver.Firefox()
+    driver.implicitly_wait(30)
 
     # Home page
-    driver.get(url)
-    driver.implicitly_wait(30)
+    driver.get(dashboard_url)
     driver.find_element_by_id("overview-tab")
 
+    # Expect overview tab's welcome message
     wait = WebDriverWait(driver, 10)
     wait.until(
         EC.text_to_be_present_in_element(
@@ -54,13 +57,234 @@ def test_dashboard(explanations):
     )
 
     # Move to data
-    # tabs_el = driver.find_element_by_id("tabs")
-    # data_tab_el = tabs_el.find_element_by_xpath("//div[contains(text(),'Data')]")
-    # data_tab_el.click()
+    tabs_el = driver.find_element_by_id("tabs")
+    data_tab_el = tabs_el.find_element_by_xpath("//span[contains(text(),'Data')]")
+    data_tab_el.click()
+
+    # Expect dropdown
+    wait.until(
+        EC.text_to_be_present_in_element(
+            (By.CLASS_NAME, "card-title"), "Select Explanation"
+        )
+    )
+    # Click on dropdown
+    data_tab_el = driver.find_element_by_id("data-tab")
+    dropdown_el = data_tab_el.find_element_by_class_name("Select-placeholder")
+    dropdown_el.click()
+    # Select histogram item
+    hist_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'Histogram')]")
+    hist_el.click()
+
+    # Expect shared container
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//div[contains(text(),'Select Components to Graph')]")
+        )
+    )
+    first_path = "//label[@for='checkbox0']"
+    second_path = "//label[@for='checkbox1']"
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, first_path)
+        )
+    )
+    # Click on first two items
+    first_el = data_tab_el.find_element_by_xpath(first_path)
+    first_el.click()
+    second_el = data_tab_el.find_element_by_xpath(second_path)
+    second_el.click()
+    # Expect two specific graphs
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-0-0")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-0-1")
+    ))
+    # Expect overall graph
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "example-overall-graph-0")
+    ))
 
     # Move to perf
-    # Move to local
+    tabs_el = driver.find_element_by_id("tabs")
+    perf_tab_el = tabs_el.find_element_by_xpath("//span[contains(text(),'Perf')]")
+    perf_tab_el.click()
+
+    # Expect dropdown
+    wait.until(
+        EC.text_to_be_present_in_element(
+            (By.CLASS_NAME, "card-title"), "Select Explanation"
+        )
+    )
+    # Click on dropdown
+    perf_tab_el = driver.find_element_by_id("perf-tab")
+    # Select LR item
+    dropdown_el = perf_tab_el.find_element_by_class_name("Select-control")
+    dropdown_el.click()
+    lr_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'LR')]")
+    lr_el.click()
+    # Select EBM item
+    dropdown_el.click()
+    ebm_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'EBM')]")
+    ebm_el.click()
+    # Expect two overall graphs
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//div[@id='perf-overall-plot-container-0']//div[contains(@id, 'example-overall-graph-')]")
+        )
+    )
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//div[@id='perf-overall-plot-container-1']//div[contains(@id, 'example-overall-graph-')]")
+        )
+    )
+
     # Move to global
+    tabs_el = driver.find_element_by_id("tabs")
+    global_tab_el = tabs_el.find_element_by_xpath("//span[contains(text(),'Global')]")
+    global_tab_el.click()
+
+    # Expect dropdown
+    wait.until(
+        EC.text_to_be_present_in_element(
+            (By.CLASS_NAME, "card-title"), "Select Explanation"
+        )
+    )
+
+    # Click on dropdown
+    global_tab_el = driver.find_element_by_id("global-tab")
+    # Select LR item
+    dropdown_el = global_tab_el.find_element_by_class_name("Select-control")
+    dropdown_el.click()
+    lr_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'LR')]")
+    lr_el.click()
+    # Select EBM item
+    dropdown_el.click()
+    ebm_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'EBM')]")
+    ebm_el.click()
+
+    # Expect shared container
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//div[contains(text(),'Select Components to Graph')]")
+        )
+    )
+    first_path = "//label[@for='checkbox0']"
+    second_path = "//label[@for='checkbox1']"
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, first_path)
+        )
+    )
+    # Click on first two items
+    first_el = global_tab_el.find_element_by_xpath(first_path)
+    first_el.click()
+    second_el = global_tab_el.find_element_by_xpath(second_path)
+    second_el.click()
+    # Expect four specific graphs
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-2-0")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-2-1")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-5-0")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-5-1")
+    ))
+    # Expect two overall graphs
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "example-overall-graph-2")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "example-overall-graph-5")
+    ))
+
+    # Move to local
+    tabs_el = driver.find_element_by_id("tabs")
+    local_tab_el = tabs_el.find_element_by_xpath("//span[contains(text(),'Local')]")
+    local_tab_el.click()
+
+    # Expect dropdown
+    wait.until(
+        EC.text_to_be_present_in_element(
+            (By.CLASS_NAME, "card-title"), "Select Explanation"
+        )
+    )
+
+    # Click on dropdown
+    local_tab_el = driver.find_element_by_id("local-tab")
+    # Select LR item
+    dropdown_el = local_tab_el.find_element_by_class_name("Select-control")
+    dropdown_el.click()
+    lr_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'LR')]")
+    lr_el.click()
+    # Select EBM item
+    dropdown_el.click()
+    ebm_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'EBM')]")
+    ebm_el.click()
+
+    # Expect two selectors
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//div[@class='gr']/div[@class='gr-col'][1]")
+        )
+    )
+    wait.until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//div[@class='gr']/div[@class='gr-col'][2]")
+        )
+    )
+    # Click on first two items for both panes
+    for pane_idx in range(2):
+        for item_idx in range(2):
+            item_path = "//div[@class='gr-col'][{0}]//label[@for='checkbox{1}']".format(pane_idx + 1, item_idx)
+            wait.until(
+                EC.presence_of_element_located(
+                    (By.XPATH, item_path)
+                )
+            )
+            item_el = local_tab_el.find_element_by_xpath(item_path)
+            item_el.click()
+    # Expect four specific graphs
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-1-0")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-1-1")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-4-0")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-4-1")
+    ))
+    # Expect two overall graphs
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "example-overall-graph-1")
+    ))
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "example-overall-graph-4")
+    ))
+
+    # Mini page
+    driver.get(mini_url)
+    driver.find_element_by_class_name("card")
+    # Expect overall graph
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "example-overall-graph--1")
+    ))
+    # Click on specific graph
+    dropdown_el = driver.find_element_by_class_name("Select-control")
+    dropdown_el.click()
+    specific_el = dropdown_el.find_element_by_xpath("//div[contains(text(),'1 : ')]")
+    specific_el.click()
+    # Expect specific graph
+    wait.until(EC.presence_of_element_located(
+        (By.ID, "graph-0-0")
+    ))
 
     # Close driver
     driver.close()

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -6,7 +6,7 @@ from ..glassbox import LogisticRegression, ExplainableBoostingClassifier
 from ..visual.interactive import set_show_addr, shutdown_show_server, show_link
 
 # Timeout for element to not show up in selenium driver.
-TIMEOUT = 180
+TIMEOUT = 60
 
 
 @pytest.fixture(scope="module")

--- a/src/python/interpret/test/test_selenium.py
+++ b/src/python/interpret/test/test_selenium.py
@@ -6,7 +6,7 @@ from ..glassbox import LogisticRegression, ExplainableBoostingClassifier
 from ..visual.interactive import set_show_addr, shutdown_show_server, show_link
 
 # Timeout for element not show up in selenium driver.
-TIMEOUT = 60
+TIMEOUT = 120
 
 
 @pytest.fixture(scope="module")

--- a/src/python/interpret/version.py
+++ b/src/python/interpret/version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
 
-__version__ = "0.1.10"
+__version__ = "0.1.11-prerelease"

--- a/src/python/interpret/visual/dashboard.py
+++ b/src/python/interpret/visual/dashboard.py
@@ -275,7 +275,6 @@ class DispatcherApp:
                     return [handler.read()]
 
             match = re.search(self.app_pattern, path_info)
-            log.debug("App pattern match: {0}".format(match))
             if match is None or self.pool.get(match.group(1), None) is None:
                 msg = "URL not supported: {0}".format(path_info)
                 log.error(msg)

--- a/src/python/interpret/visual/plot.py
+++ b/src/python/interpret/visual/plot.py
@@ -358,12 +358,16 @@ def plot_bar(data_dict, title="", xtitle="", ytitle=""):
         xaxis=dict(title=xtitle, type="category"),
         yaxis=dict(title=ytitle),
     )
+    yrange = None
+    if data_dict.get("scores_range", None) is not None:
+        scores_range = data_dict["scores_range"]
+        yrange = scores_range
     main_fig = go.Figure(data=[trace], layout=layout)
 
     # Add density
     if data_dict.get("density", None) is not None:
         figure = _plot_with_density(
-            data_dict["density"], main_fig, title=title, is_categorical=True
+            data_dict["density"], main_fig, title=title, is_categorical=True, yrange=yrange
         )
     else:
         figure = main_fig

--- a/src/python/interpret/visual/plot.py
+++ b/src/python/interpret/visual/plot.py
@@ -143,11 +143,16 @@ def plot_continuous_bar(data_dict, title=None, xtitle="", ytitle=""):
         xaxis=dict(title=xtitle),
         yaxis=dict(title=ytitle),
     )
+    yrange = None
+    if data_dict.get("scores_range", None) is not None:
+        scores_range = data_dict["scores_range"]
+        yrange = scores_range
+
     main_fig = go.Figure(data=data, layout=layout)
 
     # Add density
     if data_dict.get("density", None) is not None:
-        figure = _plot_with_density(data_dict["density"], main_fig, title=title)
+        figure = _plot_with_density(data_dict["density"], main_fig, title=title, yrange=yrange)
     else:
         figure = main_fig
 
@@ -219,6 +224,7 @@ def _plot_with_density(
     title="",
     xtitle="",
     ytitle="",
+    yrange=None,
     is_categorical=False,
     density_name="Distribution",
 ):
@@ -229,6 +235,9 @@ def _plot_with_density(
     figure = _two_plot(main_fig, bar_fig, title=title, share_xaxis=is_categorical)
     figure["layout"]["yaxis1"].update(title="Score")
     figure["layout"]["yaxis2"].update(title="Density")
+
+    if yrange is not None:
+        figure["layout"]["yaxis1"].update(range=yrange)
 
     return figure
 
@@ -434,6 +443,9 @@ def plot_pairwise_heatmap(data_dict, title="", xtitle="", ytitle=""):
     bin_vals = data_dict["scores"]
 
     heatmap = go.Heatmap(z=bin_vals.T, x=bin_labels_left, y=bin_labels_right)
+    if data_dict.get("scores_range", None) is not None:
+        heatmap["zmin"] = data_dict["scores_range"][0]
+        heatmap["zmax"] = data_dict["scores_range"][1]
 
     layout = go.Layout(title=title, xaxis=dict(title=xtitle), yaxis=dict(title=ytitle))
     figure = go.Figure(data=[heatmap], layout=layout)

--- a/src/python/interpret/visual/udash.py
+++ b/src/python/interpret/visual/udash.py
@@ -189,7 +189,7 @@ def gen_overall_plot(exp, model_idx):
         )
     elif isinstance(figure, dash_base.Component):
         output_graph = figure
-        output_graph.id = ("example-overall-graph-{0}".format(model_idx),)
+        output_graph.id = "example-overall-graph-{0}".format(model_idx)
     else:  # pragma: no cover
         _type = type(figure)
         log.warning("Visualization type not supported: {0}".format(_type))
@@ -241,7 +241,7 @@ def gen_plot(exp, picker, model_idx, counter):
         )
     elif isinstance(figure, dash_base.Component):
         output_graph = figure
-        output_graph.id = ("graph-{0}-{1}".format(model_idx, counter),)
+        output_graph.id = "graph-{0}-{1}".format(model_idx, counter)
     else:  # pragma: no cover
         _type = type(figure)
         log.warning("Visualization type not supported: {0}".format(_type))

--- a/src/python/interpret/visual/udash.py
+++ b/src/python/interpret/visual/udash.py
@@ -127,36 +127,13 @@ def generate_app_mini(
         else:
             return gen_plot(explanation, int(value), 0, 0)
 
-    @server.errorhandler(404)
-    def page_not_found(_):
-        from flask import request
-
-        path = request.path
-        msg = "Could not find page: {0}".format(path)
-
-        log.error(msg)
-        return msg, 404
-
     @server.errorhandler(Exception)
-    def handle_error(e):
+    def handle_error(e):  # pragma: no cover
         log.error(e, exc_info=True)
         return "Internal Server Error caught by udash. See logs if available.", 500
 
-    @app.server.route("/shutdown", methods=["POST"])
-    def shutdown():
-        return shutdown_server(app)
-
     log.info("Generated mini dash")
     return app
-
-
-def shutdown_server(app):
-    log.info("ENDPOINT: Shutting down server")
-    server = app.config["server"]
-    server.stop()
-    log.info("ENDPOINT: Shut down server")
-
-    return "Shutdown Dashboard."
 
 
 def gen_overall_plot(exp, model_idx):
@@ -800,7 +777,7 @@ The explanations available are split into tabs, each covering an aspect of the p
         return html.Div(output_div)
 
     @server.errorhandler(Exception)
-    def handle_error(e):
+    def handle_error(e):  # pragma: no cover
         log.error(e, exc_info=True)
         return "Internal Server Error caught by udash. See logs if available.", 500
 
@@ -833,10 +810,6 @@ The explanations available are split into tabs, each covering an aspect of the p
         if tab is None or tab != "global":
             return None
         return gen_tab(tab)
-
-    @app.server.route("/shutdown", methods=["POST"])
-    def shutdown():
-        return shutdown_server(app)
 
     log.info("Generated full dash")
     return app
@@ -912,7 +885,7 @@ def generate_app(
         shared_frames = {supported_type: False for supported_type in supported_types}
     elif isinstance(share_tables, dict):
         shared_frames = share_tables
-    else:
+    else:  # pragma: no cover
         raise Exception("share_tables option must be True|False|None or dict.")
 
     new_options["share_tables"] = shared_frames

--- a/src/python/interpret/visual/udash.py
+++ b/src/python/interpret/visual/udash.py
@@ -213,7 +213,7 @@ def gen_overall_plot(exp, model_idx):
     elif isinstance(figure, dash_base.Component):
         output_graph = figure
         output_graph.id = ("example-overall-graph-{0}".format(model_idx),)
-    else:
+    else:  # pragma: no cover
         _type = type(figure)
         log.warning("Visualization type not supported: {0}".format(_type))
         raise Exception("Not supported visualization type: {0}".format(_type))
@@ -265,7 +265,7 @@ def gen_plot(exp, picker, model_idx, counter):
     elif isinstance(figure, dash_base.Component):
         output_graph = figure
         output_graph.id = ("graph-{0}-{1}".format(model_idx, counter),)
-    else:
+    else:  # pragma: no cover
         _type = type(figure)
         log.warning("Visualization type not supported: {0}".format(_type))
         raise Exception("Not supported visualization type: {0}".format(_type))


### PR DESCRIPTION
multi-class post-processing added to 
interpret/src/python/interpret/glassbox/ebm/multiclass_postprocess.py.

Currently omitting the center step, since we haven't discussed the input & output format for the centering. It is assumed that the centering will take a string list containing 'categorical' or 'numerical'. But what is the output format? I assume we then have a list 2D array updated_feature_graphs as well as a 1D array intercept?

