### PR TITLE
Add quantile bins

### DIFF
--- a/python/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret/glassbox/ebm/ebm.py
@@ -170,14 +170,16 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                 if len(uniq_vals) < self.cont_n_bins:
                     bins = list(sorted(uniq_vals))
                 else:
-                    if self.binning_strategy == "uniform":
+                    if self.binning_strategy == 'uniform':
                         bins = self.cont_n_bins
-                    else:
+                    elif self.binning_strategy == 'quantile':
                         bins = np.unique(np.quantile(col_data, q=np.linspace(0, 1, self.cont_n_bins + 1)))
+                    else: 
+                        raise ValueError(f"Unknown binning_strategy: '{self.binning_strategy}'.")
+                
                 _, bin_edges = np.histogram(col_data, bins=bins)
 
                 hist_counts, hist_edges = np.histogram(col_data, bins="doane")
-
                 self.col_bin_edges_[col_idx] = bin_edges
 
                 self.hist_edges_[col_idx] = hist_edges

--- a/python/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret/glassbox/ebm/ebm.py
@@ -173,7 +173,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                     if self.density_bins == False:
                         bins = self.cont_n_bins
                     else:
-                        bins = sorted([np.percentile(col_data, q = (i/self.cont_n_bins)*100) for i in list(range(self.cont_n_bins+1))])
+                        bins = np.unique(np.quantile(col_data, q=np.linspace(0, 1, self.cont_n_bins + 1)))
 
                 _, bin_edges = np.histogram(col_data, bins=bins)
 

--- a/python/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret/glassbox/ebm/ebm.py
@@ -103,7 +103,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
         missing_constant=0,
         unknown_constant=0,
         feature_names=None,
-        density_bins=False,
+        binning_strategy="uniform",
     ):
         """ Initializes EBM preprocessor.
 
@@ -114,14 +114,14 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
             missing_constant: Missing encoded as this constant.
             unknown_constant: Unknown encoded as this constant.
             feature_names: Feature names as list.
-            density_bins: Boolean to compute bins according to density if True or equidistant if False. 
+            binning_strategy: Strategy to compute bins according to density if "quantile" or equidistant if "uniform". 
         """
         self.schema = schema
         self.cont_n_bins = cont_n_bins
         self.missing_constant = missing_constant
         self.unknown_constant = unknown_constant
         self.feature_names = feature_names
-        self.density_bins = density_bins
+        self.binning_strategy = binning_strategy
 
     def fit(self, X):
         """ Fits transformer to provided instances.
@@ -170,11 +170,10 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                 if len(uniq_vals) < self.cont_n_bins:
                     bins = list(sorted(uniq_vals))
                 else:
-                    if self.density_bins == False:
+                    if self.binning_strategy == "uniform":
                         bins = self.cont_n_bins
                     else:
                         bins = np.unique(np.quantile(col_data, q=np.linspace(0, 1, self.cont_n_bins + 1)))
-
                 _, bin_edges = np.histogram(col_data, bins=bins)
 
                 hist_counts, hist_edges = np.histogram(col_data, bins="doane")
@@ -699,7 +698,7 @@ class BaseEBM(BaseEstimator):
         n_jobs=-2,
         random_state=42,
         # Preprocessor
-        density_bins=False,
+        binning_strategy="uniform",
     ):
 
         # Arguments for explainer
@@ -733,7 +732,7 @@ class BaseEBM(BaseEstimator):
         self.random_state = random_state
 
         # Arguments for preprocessor
-        self.density_bins = density_bins
+        self.binning_strategy = binning_strategy
 
     def fit(self, X, y):
         X, y, self.feature_names, _ = unify_data(
@@ -747,7 +746,7 @@ class BaseEBM(BaseEstimator):
                 X, feature_names=self.feature_names, feature_types=self.feature_types
             )
 
-        self.preprocessor_ = EBMPreprocessor(schema=self.schema_, density_bins=self.density_bins)
+        self.preprocessor_ = EBMPreprocessor(schema=self.schema_, binning_strategy=self.binning_strategy)
         self.preprocessor_.fit(X)
 
         if is_classifier(self):
@@ -1252,7 +1251,7 @@ class ExplainableBoostingRegressor(BaseEBM, RegressorMixin, ExplainerMixin):
         n_jobs=-2,
         random_state=42,
         # Preprocessor
-        density_bins=False,
+        binning_strategy="uniform",
     ):
 
         super(ExplainableBoostingRegressor, self).__init__(
@@ -1281,7 +1280,7 @@ class ExplainableBoostingRegressor(BaseEBM, RegressorMixin, ExplainerMixin):
             n_jobs=n_jobs,
             random_state=random_state,
             # Preprocessor
-            density_bins=density_bins,
+            binning_strategy=binning_strategy,
         )
 
     def predict(self, X):

--- a/python/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret/glassbox/ebm/ebm.py
@@ -175,7 +175,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                     elif self.binning_strategy == 'quantile':
                         bins = np.unique(np.quantile(col_data, q=np.linspace(0, 1, self.cont_n_bins + 1)))
                     else: 
-                        raise ValueError(f"Unknown binning_strategy: '{self.binning_strategy}'.")
+                        raise ValueError("Unknown binning_strategy: '{}'.".format(self.binning_strategy))
                 
                 _, bin_edges = np.histogram(col_data, bins=bins)
 

--- a/python/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret/glassbox/ebm/ebm.py
@@ -103,6 +103,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
         missing_constant=0,
         unknown_constant=0,
         feature_names=None,
+        density_bins=False,
     ):
         """ Initializes EBM preprocessor.
 
@@ -113,12 +114,14 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
             missing_constant: Missing encoded as this constant.
             unknown_constant: Unknown encoded as this constant.
             feature_names: Feature names as list.
+            density_bins: Boolean to compute bins according to density if True or equidistant if False. 
         """
         self.schema = schema
         self.cont_n_bins = cont_n_bins
         self.missing_constant = missing_constant
         self.unknown_constant = unknown_constant
         self.feature_names = feature_names
+        self.density_bins = density_bins
 
     def fit(self, X):
         """ Fits transformer to provided instances.
@@ -167,11 +170,15 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                 if len(uniq_vals) < self.cont_n_bins:
                     bins = list(sorted(uniq_vals))
                 else:
-                    bins = self.cont_n_bins
+                    if self.density_bins == False:
+                        bins = self.cont_n_bins
+                    else:
+                        bins = sorted([np.percentile(col_data, q = (i/self.cont_n_bins)*100) for i in list(range(self.cont_n_bins+1))])
 
                 _, bin_edges = np.histogram(col_data, bins=bins)
 
                 hist_counts, hist_edges = np.histogram(col_data, bins="doane")
+
                 self.col_bin_edges_[col_idx] = bin_edges
 
                 self.hist_edges_[col_idx] = hist_edges
@@ -691,6 +698,8 @@ class BaseEBM(BaseEstimator):
         # Overall
         n_jobs=-2,
         random_state=42,
+        # Preprocessor
+        density_bins=False,
     ):
 
         # Arguments for explainer
@@ -723,6 +732,9 @@ class BaseEBM(BaseEstimator):
         self.n_jobs = n_jobs
         self.random_state = random_state
 
+        # Arguments for preprocessor
+        self.density_bins = density_bins
+
     def fit(self, X, y):
         X, y, self.feature_names, _ = unify_data(
             X, y, self.feature_names, self.feature_types
@@ -735,7 +747,7 @@ class BaseEBM(BaseEstimator):
                 X, feature_names=self.feature_names, feature_types=self.feature_types
             )
 
-        self.preprocessor_ = EBMPreprocessor(schema=self.schema_)
+        self.preprocessor_ = EBMPreprocessor(schema=self.schema_, density_bins=self.density_bins)
         self.preprocessor_.fit(X)
 
         if is_classifier(self):
@@ -1239,6 +1251,8 @@ class ExplainableBoostingRegressor(BaseEBM, RegressorMixin, ExplainerMixin):
         # Overall
         n_jobs=-2,
         random_state=42,
+        # Preprocessor
+        density_bins=False,
     ):
 
         super(ExplainableBoostingRegressor, self).__init__(
@@ -1266,6 +1280,8 @@ class ExplainableBoostingRegressor(BaseEBM, RegressorMixin, ExplainerMixin):
             # Overall
             n_jobs=n_jobs,
             random_state=random_state,
+            # Preprocessor
+            density_bins=density_bins,
         )
 
     def predict(self, X):


### PR DESCRIPTION
### Quantile bins
#### Why 
When we have outliers, using equal-width bins may induce a reduction of accuracy. 
Bins containing the same number of data, quantile bins, increase the resolution of shape functions in the region of interest.
This change is also suggested in issue https://github.com/microsoft/interpret/issues/42. 
#### How 
Add the parameter `binning_strategy` to the `ExplainableBoostingRegressor`. It can take two values for now : 
- `'uniform'` to make equal-width bins
- `'quantile'` to make bins having same number of data

Names are inspired by `KBinsDiscretizer` from scikit-learn.