### PR TITLE
adding model-specific glassbox explainer extension namespace

### DIFF
--- a/python/interpret/ext/blackbox/__init__.py
+++ b/python/interpret/ext/blackbox/__init__.py
@@ -4,7 +4,7 @@
 import logging
 import sys
 
-from interpret.ext.extension_utils import load_class_extensions
+from interpret.ext.extension_utils import load_class_extensions, _is_valid_explainer
 
 module_logger = logging.getLogger(__name__)
 
@@ -14,26 +14,7 @@ BLACKBOX_EXTENSION_KEY = "interpret_ext_blackbox"
 # TODO: More checks for blackbox validation, specifically on spec for explainer/explanation when instantiated.
 def _is_valid_blackbox_explainer(proposed_blackbox_explainer):
     try:
-        explainer_type = proposed_blackbox_explainer.explainer_type
-        available_explanations = proposed_blackbox_explainer.available_explanations
-
-        if explainer_type != "blackbox":
-            module_logger.warning("Proposed explainer is not a blackbox.")
-            return False
-
-        for available_explanation in available_explanations:
-            has_explain_method = hasattr(
-                proposed_blackbox_explainer, "explain_" + available_explanation
-            )
-            if not has_explain_method:
-                module_logger.warning(
-                    "Proposed explainer has available explanation {} but has no respective method.".format(
-                        available_explanation
-                    )
-                )
-                return False
-
-        return True
+        return _is_valid_explainer(proposed_blackbox_explainer, "blackbox")
 
     except Exception as e:
         module_logger.warning("Validate function threw exception {}".format(e))

--- a/python/interpret/ext/glassbox/__init__.py
+++ b/python/interpret/ext/glassbox/__init__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
+import logging
+import sys
+
+from interpret.ext.extension_utils import load_class_extensions, _is_valid_explainer
+
+module_logger = logging.getLogger(__name__)
+
+GLASSBOX_EXTENSION_KEY = "interpret_ext_glassbox"
+
+
+# TODO: More checks for glassbox validation, specifically on spec for explainer/explanation when instantiated.
+def _is_valid_glassbox_explainer(proposed_glassbox_explainer):
+    try:
+        is_valid_explainer = _is_valid_explainer(proposed_glassbox_explainer, "glassbox")
+        has_fit = hasattr(proposed_glassbox_explainer, "fit")
+        has_predict = hasattr(proposed_glassbox_explainer, "predict")
+        if not is_valid_explainer:
+            module_logger.warning("Explainer not valid due to missing explain_local or global function.")
+        if not has_fit:
+            module_logger.warning("Explainer not valid due to missing fit function.")
+        if not has_predict:
+            module_logger.warning("Explainer not valid due to missing predict function.")
+        return is_valid_explainer and has_fit and has_predict
+
+    except Exception as e:
+        module_logger.warning("Validate function threw exception {}".format(e))
+        return False
+
+
+# How to get the current module
+# https://stackoverflow.com/questions/1676835
+current_module = sys.modules[__name__]
+
+load_class_extensions(
+    current_module, GLASSBOX_EXTENSION_KEY, _is_valid_glassbox_explainer
+)

--- a/python/interpret/ext/glassbox/example_glassbox_explainer_ext.py
+++ b/python/interpret/ext/glassbox/example_glassbox_explainer_ext.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
+from interpret.api.base import ExplainerMixin, ExplanationMixin
+
+
+class ExampleExplanation(ExplanationMixin):
+    explanation_type = "local"
+
+    def __init__(self):
+        self._internal_obj = None
+
+    def data(self, key=None):
+        return None
+
+    def visualize(self, key=None):
+        return None
+
+
+class ExampleExplainer(ExplainerMixin):
+    available_explanations = ["local"]
+    explainer_type = "glassbox"
+
+    def __init__(
+        self, feature_names=None, feature_types=None
+    ):
+        self.feature_names = feature_names
+        self.feature_types = feature_types
+
+    def fit(self, X, y):
+        return self
+
+    def predict(self, X):
+        return None
+
+    def predict_proba(self, X):
+        return None
+
+    def explain_local(self, X, y=None, name=None):
+        return ExampleExplanation()

--- a/python/interpret/ext/glassbox/test/__init__.py
+++ b/python/interpret/ext/glassbox/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license

--- a/python/interpret/ext/glassbox/test/test_example_glassbox_explainer_ext.py
+++ b/python/interpret/ext/glassbox/test/test_example_glassbox_explainer_ext.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
+from ....glassbox import LinearRegression
+from ....api.base import ExplainerMixin
+from .. import _is_valid_glassbox_explainer
+
+
+def test_invalid_glassbox_explainer():
+    # NOTE: Available method claims local exists, but there is not respective method.
+    class InvalidGlassboxExplainer(ExplainerMixin):
+        explainer_type = "glassbox"
+        available_explanations = ["local"]
+
+    class NotEvenAnExplainer:
+        def nothing(self):
+            pass
+
+    assert not _is_valid_glassbox_explainer(LinearRegression)
+    assert not _is_valid_glassbox_explainer(InvalidGlassboxExplainer)
+    assert not _is_valid_glassbox_explainer(NotEvenAnExplainer)


### PR DESCRIPTION
adding model-specific glassbox explainer extension namespace

Note: this was for whitebox models due to reason below, but I changed it to glassbox because whitebox (or graybox) is already being done on a separate branch

There needs to be a separate extension mechanism for model-specific explainers such as SHAP DeepExplainer, LinearExplainer and TreeExplainer, which don't fall under the blackbox extension