### PR TITLE
fix namespace collisions with interpret package

### DIFF
--- a/python/interpret/__init__.py
+++ b/python/interpret/__init__.py
@@ -22,3 +22,5 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 # Set name of package
 name = "interpret"
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/api/__init__.py
+++ b/python/interpret/api/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/api/test/__init__.py
+++ b/python/interpret/api/test/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/blackbox/__init__.py
+++ b/python/interpret/blackbox/__init__.py
@@ -5,3 +5,5 @@ from .lime import LimeTabular  # noqa: F401
 from .shap import ShapKernel  # noqa: F401
 from .sensitivity import MorrisSensitivity  # noqa: F401
 from .partialdependence import PartialDependence  # noqa: F401
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/blackbox/test/__init__.py
+++ b/python/interpret/blackbox/test/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/data/__init__.py
+++ b/python/interpret/data/__init__.py
@@ -2,3 +2,5 @@
 # Distributed under the MIT software license
 
 from .response import ClassHistogram, Marginal  # noqa: F401
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/ext/__init__.py
+++ b/python/interpret/ext/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/glassbox/__init__.py
+++ b/python/interpret/glassbox/__init__.py
@@ -6,3 +6,5 @@ from .linear import LogisticRegression, LinearRegression  # noqa: F401
 from .skoperules import DecisionListClassifier  # noqa: F401
 from .ebm.ebm import ExplainableBoostingClassifier  # noqa: F401
 from .ebm.ebm import ExplainableBoostingRegressor  # noqa: F401
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/glassbox/ebm/__init__.py
+++ b/python/interpret/glassbox/ebm/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/glassbox/test/__init__.py
+++ b/python/interpret/glassbox/test/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/perf/__init__.py
+++ b/python/interpret/perf/__init__.py
@@ -3,3 +3,5 @@
 
 from .curve import ROC, PR  # noqa: F401
 from .regression import RegressionPerf  # noqa: F401
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/test/__init__.py
+++ b/python/interpret/test/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/utils/__init__.py
+++ b/python/interpret/utils/__init__.py
@@ -3,3 +3,5 @@
 
 from .all import *  # noqa: F401,F403
 from .distributed import *  # noqa: F401,F403
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/interpret/visual/__init__.py
+++ b/python/interpret/visual/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
fix namespace collisions with interpret package

I really only need the change in the top-level  python/interpret/\_\_init\_\_.py, but I made it consistent across all init files.
The issue I was running into is that with another package, when using the same interpret.community namespace, it could not find my package and gave me errors like:

```
    from interpret.community.tabular_explainer import TabularExplainer
E   ModuleNotFoundError: No module named 'interpret.community'
```

relevant stack overflow:

https://stackoverflow.com/questions/2699287/what-is-path-useful-for
