### PR TITLE
Float sens prediction vals

### DIFF
--- a/python/interpret-core/interpret/blackbox/sensitivity.py
+++ b/python/interpret-core/interpret/blackbox/sensitivity.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
 
-from abc import ABC, abstractmethod
-
-import numpy as np
-
 from ..api.base import ExplainerMixin
 from ..api.templates import FeatureValueExplanation
-from ..utils import (gen_global_selector, gen_name_from_class, unify_data,
-                     unify_predict_fn)
+from ..utils import unify_predict_fn, unify_data
+from ..utils import gen_name_from_class, gen_global_selector
+
+from abc import ABC, abstractmethod
+import numpy as np
 
 
 class SamplerMixin(ABC):
@@ -68,7 +67,7 @@ class MorrisSensitivity(ExplainerMixin):
 
         samples = self.sampler.sample()
         problem = self.sampler.gen_problem_from_data(self.data, self.feature_names)
-        analysis = morris.analyze(problem, samples, self.predict_fn(samples))
+        analysis = morris.analyze(problem, samples, self.predict_fn(samples).astype(float))
 
         mu = analysis["mu"]
         mu_star = analysis["mu_star"]

--- a/python/interpret-core/interpret/blackbox/sensitivity.py
+++ b/python/interpret-core/interpret/blackbox/sensitivity.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
 
+from abc import ABC, abstractmethod
+
+import numpy as np
+
 from ..api.base import ExplainerMixin
 from ..api.templates import FeatureValueExplanation
-from ..utils import unify_predict_fn, unify_data
-from ..utils import gen_name_from_class, gen_global_selector
-
-from abc import ABC, abstractmethod
-import numpy as np
+from ..utils import (gen_global_selector, gen_name_from_class, unify_data,
+                     unify_predict_fn)
 
 
 class SamplerMixin(ABC):

--- a/python/interpret-core/interpret/utils/shap.py
+++ b/python/interpret-core/interpret/utils/shap.py
@@ -17,9 +17,6 @@ def shap_explain_local(explainer, X, y=None, name=None, is_classification=False)
         all_shap_values = explainer.shap.shap_values(X)
         expected_value = explainer.shap.expected_value
 
-    print(len(all_shap_values))
-    print(all_shap_values)
-
     predictions = explainer.predict_fn(X)
 
     data_dicts = []


### PR DESCRIPTION
Hi,

I am proposing to cast the prediction array being passed to the morris analyze function to float as morris requires the array to be float values.

The reason for this is for the `.predict` function of sklearn classifiers return a list of integers causing the global explainer morris technique to throw an error.

Whether or not it makes more sense to use `.predict` vs. `.predict_proba`, all other explainer analysis methods pass when using `.predict`, so this change will make it so that all explainer analysis methods will work with `.predict_proba` and `.predict` when explaining sklearn classifiers.

EDIT: Also removed 2 print statements to clean up output when using the shap local explainer.

Ashton