### PR TITLE
Add checks to ensure model has been fitted before running explain global/local

### DIFF
--- a/python/interpret-core/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret-core/interpret/glassbox/ebm/ebm.py
@@ -1048,6 +1048,8 @@ class BaseEBM(BaseEstimator):
         if name is None:
             name = gen_name_from_class(self)
 
+        check_is_fitted(self, "has_fitted_")
+
         # Obtain min/max for model scores
         lower_bound = np.inf
         upper_bound = -np.inf
@@ -1172,6 +1174,8 @@ class BaseEBM(BaseEstimator):
         # Values are the model graph score per respective attribute set.
         if name is None:
             name = gen_name_from_class(self)
+
+        check_is_fitted(self, "has_fitted_")
 
         X, y, _, _ = unify_data(X, y, self.feature_names, self.feature_types)
         instances = self.preprocessor_.transform(X)


### PR DESCRIPTION
Called the check_is_fitted() function from the sklearn library to ensure that user receives a helpful error message when they try to get the local or global explanation without fitting the model